### PR TITLE
👷 Fix JKube multimodule builder

### DIFF
--- a/fuse-products/src/main/resources/openshift/csb/jkube-fileset-config.xml
+++ b/fuse-products/src/main/resources/openshift/csb/jkube-fileset-config.xml
@@ -1,7 +1,7 @@
 <configuration>
     <images>
         <image>
-            <name>jkube-resources</name>
+            <name>${project.build.finalName}</name>
             <build>
                 <from>${jkube.generator.from}</from>
                 <assembly>


### PR DESCRIPTION
in case of multi-module integrations, the build fails because it uses always the same OCP BuildConfig (named `jkube-resources`), so every module overrides the previous one; with this change a BuildConfig with name taken from  `project.build.finalName` will be created