### PR TITLE
[MGDOBR-834] Add support for using multiple predefined Webhook tokens

### DIFF
--- a/system-x/services/webhook/src/main/java/software/tnb/webhook/account/WebhookAccount.java
+++ b/system-x/services/webhook/src/main/java/software/tnb/webhook/account/WebhookAccount.java
@@ -1,0 +1,50 @@
+package software.tnb.webhook.account;
+
+import software.tnb.common.account.Account;
+import software.tnb.common.account.WithId;
+
+import java.util.Map;
+
+/**
+ * Expects following Webhook.site definition:
+ *
+ *   webhook-site:
+ *     credentials:
+ *       tokens:
+ *         [name]:
+ *           token: [token]
+ *         ...
+ */
+public class WebhookAccount implements Account, WithId {
+    private Map<String, Token> tokens;
+
+    @Override
+    public String credentialsId() {
+        return "webhook-site";
+    }
+
+    public String token(String tokenName) {
+        Token token = tokens.get(tokenName);
+        if (token == null) {
+            throw new IllegalArgumentException("Unknown token " + tokenName);
+        }
+        return token.token;
+    }
+    
+    public void setTokens(Map<String, Token> tokens) {
+        this.tokens = tokens;
+    }
+
+    public static class Token {
+        private String token;
+
+        public String token() {
+            return token;
+        }
+
+        public void setToken(String token) {
+            this.token = token;
+        }
+    }
+
+}

--- a/system-x/services/webhook/src/main/java/software/tnb/webhook/service/Webhook.java
+++ b/system-x/services/webhook/src/main/java/software/tnb/webhook/service/Webhook.java
@@ -1,6 +1,8 @@
 package software.tnb.webhook.service;
 
+import software.tnb.common.account.Accounts;
 import software.tnb.common.service.Service;
+import software.tnb.webhook.account.WebhookAccount;
 import software.tnb.webhook.validation.WebhookValidation;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -14,7 +16,16 @@ import com.google.auto.service.AutoService;
 public class Webhook implements Service {
     private static final Logger LOG = LoggerFactory.getLogger(Webhook.class);
 
+    private WebhookAccount account;
     private WebhookValidation validation;
+
+    public WebhookAccount account() {
+        if (account == null) {
+            LOG.debug("Creating new Webhook account");
+            account = Accounts.get(WebhookAccount.class);
+        }
+        return account;
+    }
 
     public WebhookValidation validation() {
         return validation;

--- a/system-x/services/webhook/src/main/java/software/tnb/webhook/validation/RequestQueryParameters.java
+++ b/system-x/services/webhook/src/main/java/software/tnb/webhook/validation/RequestQueryParameters.java
@@ -1,0 +1,76 @@
+package software.tnb.webhook.validation;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Class to hold the Webhook request query parameters
+ */
+public class RequestQueryParameters {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").withZone(ZoneId.systemDefault());
+
+    private StringBuilder parameters;
+
+    public RequestQueryParameters setSorting(QuerySorting sorting) {
+        appendParameter("sorting", sorting.value);
+        return this;
+    }
+
+    public RequestQueryParameters setRequestsPerPage(int requests) {
+        appendParameter("per_page", String.valueOf(requests));
+        return this;
+    }
+
+    public RequestQueryParameters setPage(int page) {
+        appendParameter("page", String.valueOf(page));
+        return this;
+    }
+
+    public RequestQueryParameters setDateFrom(Instant dateFrom) {
+        appendParameter("date_from", DATE_FORMATTER.format(dateFrom));
+        return this;
+    }
+
+    public RequestQueryParameters setDateTo(Instant dateFrom) {
+        appendParameter("date_to", DATE_FORMATTER.format(dateFrom));
+        return this;
+    }
+
+    public RequestQueryParameters setQuery(String query) {
+        appendParameter("query", query);
+        return this;
+    }
+
+    private void appendParameter(String name, String value) {
+        if (parameters == null) {
+            parameters = new StringBuilder("?");
+        } else {
+            parameters.append("&");
+        }
+        parameters.append(name);
+        parameters.append("=");
+        parameters.append(value);
+    }
+
+    @Override
+    public String toString() {
+        return parameters.toString();
+    }
+
+    public enum QuerySorting {
+        OLDEST("oldest"),
+        NEWEST("newest");
+
+        private String value;
+
+        QuerySorting(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/system-x/services/webhook/src/main/java/software/tnb/webhook/validation/WebhookValidation.java
+++ b/system-x/services/webhook/src/main/java/software/tnb/webhook/validation/WebhookValidation.java
@@ -34,6 +34,10 @@ public class WebhookValidation {
     }
 
     public void clearEndpoint() {
+        clearEndpoint(token);
+    }
+
+    public void clearEndpoint(String token) {
         final String url = String.format("%s/token/%s/request", WEBHOOK_ENDPOINT, token);
         LOG.debug("Cleaning endpoint {}", url);
         client.delete(url);
@@ -46,7 +50,20 @@ public class WebhookValidation {
     }
 
     public List<JSONObject> getRequests() {
-        final String url = String.format("%s/token/%s/requests", WEBHOOK_ENDPOINT, token);
+        return getRequests(token);
+    }
+
+    public List<JSONObject> getRequests(String token) {
+        return getRequests(token, null);
+    }
+
+    public List<JSONObject> getRequests(RequestQueryParameters queryParameters) {
+        return getRequests(token, queryParameters);
+    }
+
+    public List<JSONObject> getRequests(String token, RequestQueryParameters queryParameters) {
+        String parameters = queryParameters == null ? "" : queryParameters.toString();
+        final String url = String.format("%s/token/%s/requests%s", WEBHOOK_ENDPOINT, token, parameters);
         return new JSONObject(client.get(url).getBody()).getJSONArray("data")
             .toList().stream().map(o -> new JSONObject((Map) o)).collect(Collectors.toList());
     }


### PR DESCRIPTION
Due to Webhook.site FUP the creation of a new token for each test suite execution would cause FUP violation in our tests.
So, adding a support for using multiple predefined tokens.