### PR TITLE
[FUSEQE-18821] Fix regexp in KnativeValidation

### DIFF
--- a/system-x/services/knative/src/main/java/software/tnb/knative/validation/KnativeValidation.java
+++ b/system-x/services/knative/src/main/java/software/tnb/knative/validation/KnativeValidation.java
@@ -21,7 +21,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 public class KnativeValidation {
     private static final Logger LOG = LoggerFactory.getLogger(KnativeValidation.class);
     // This string is from the error message when you try to create a resource with invalid name
-    private static final String NAME_VALIDATION_REGEX = "[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*";
+    private static final String NAME_VALIDATION_REGEX = "[a-z]([-a-z0-9]*[a-z0-9])?";
 
     private final KnativeClient client;
 
@@ -81,8 +81,8 @@ public class KnativeValidation {
 
     private void validateName(String name) {
         if (!name.matches(NAME_VALIDATION_REGEX)) {
-            throw new IllegalArgumentException("Name must consist of lower case alphanumeric characters, '-' or '.',"
-                + " and must start and end with an alphanumeric character (was: " + name + ")");
+            throw new IllegalArgumentException("Name must consist of lower case alphanumeric characters, '-'"
+                + " and must start and end with an alphabetic character (was: " + name + ")");
         }
     }
 }


### PR DESCRIPTION
I observed lately that `createOrReplace` throws consistently
`class [Ljava.lang.Object; cannot be cast to class [Lio.fabric8.kubernetes.api.model.HasMetadata; ([Ljava.lang.Object; is in module java.base of loader 'bootstrap'; [Lio.fabric8.kubernetes.api.model.HasMetadata; is in unnamed module of loader 'app')`
(Concerned classes: [BaseOperation.java](https://github.com/fabric8io/kubernetes-client/blob/5.12/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/BaseOperation.java), [InOutCreateable.java](https://github.com/fabric8io/kubernetes-client/blob/5.12/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/InOutCreateable.java), [CreateOrReplaceable.java](https://github.com/fabric8io/kubernetes-client/blob/5.12/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java))
Resulting in 
```
$ oc get broker
NAME    URL   AGE   READY   REASON
9cd2d         12m   False   NoAddress
```