### PR TITLE
fix knative operator installation issue: 'OwnNamespace InstallModeType not supported …"

### DIFF
--- a/system-x/services/knative/src/main/java/software/tnb/knative/resource/OpenshiftKnative.java
+++ b/system-x/services/knative/src/main/java/software/tnb/knative/resource/OpenshiftKnative.java
@@ -131,4 +131,10 @@ public class OpenshiftKnative extends Knative implements OpenshiftDeployable, Wi
     public String operatorName() {
         return "serverless-operator";
     }
+
+    @Override
+    public boolean clusterWide() {
+        return true;
+    }
+
 }


### PR DESCRIPTION
With commit a1b66c31ade92ee629a5e7a4d6f37486b488e1cc unfortunately we lost the cluster wide (which previously was in this way: https://github.com/tnb-software/TNB/blob/235e0229bc855f226198720ba666176704b932b5/system-x/services/knative/src/main/java/software/tnb/knative/service/Knative.java#L114-L115) installation of knative operator, causing the error 'OwnNamespace InstallModeType not supported …". This PR is fixing this issue.