### PR TITLE
Bump google dependencies

### DIFF
--- a/system-x/services/google/api/mail/pom.xml
+++ b/system-x/services/google/api/mail/pom.xml
@@ -14,7 +14,7 @@
     <name>TNB :: System-X :: Services :: Google :: API :: Mail</name>
 
     <properties>
-        <google.mail.client.version>v1-rev20230116-2.0.0</google.mail.client.version>
+        <google.mail.client.version>v1-rev20230123-2.0.0</google.mail.client.version>
     </properties>
 
     <dependencies>

--- a/system-x/services/google/pom.xml
+++ b/system-x/services/google/pom.xml
@@ -17,7 +17,7 @@
 
     <properties>
         <google-api.client.version>2.1.1</google-api.client.version>
-        <google-auth-oauth.version>1.14.0</google-auth-oauth.version>
+        <google-auth-oauth.version>1.15.0</google-auth-oauth.version>
     </properties>
 
     <dependencyManagement>

--- a/system-x/services/google/pom.xml
+++ b/system-x/services/google/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <google-api.client.version>2.1.1</google-api.client.version>
+        <google-api.client.version>2.2.0</google-api.client.version>
         <google-auth-oauth.version>1.15.0</google-auth-oauth.version>
     </properties>
 


### PR DESCRIPTION
Bumps google-auth-library-oauth2-http from 1.14.0 to 1.15.0.

---
updated-dependencies:
- dependency-name: com.google.auth:google-auth-library-oauth2-http
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>