### PR TITLE
🐛 Fix ES host definition adding port, like local

### DIFF
--- a/system-x/services/elasticsearch/src/main/java/software/tnb/elasticsearch/resource/openshift/OpenshiftElasticsearch.java
+++ b/system-x/services/elasticsearch/src/main/java/software/tnb/elasticsearch/resource/openshift/OpenshiftElasticsearch.java
@@ -127,7 +127,7 @@ public class OpenshiftElasticsearch extends Elasticsearch implements ReusableOpe
 
     @Override
     public String host() {
-        return inClusterHostname();
+        return inClusterHostname() + ":9200";
     }
 
     @Override


### PR DESCRIPTION
there are some differences between local execution and execution on OCP cluster, in local execution the `host()` method contains port