### PR TITLE
[Splunk] Add older version into CRD without schema

### DIFF
--- a/system-x/services/splunk/src/main/resources/splunk-crds.yaml
+++ b/system-x/services/splunk/src/main/resources/splunk-crds.yaml
@@ -4153,6 +4153,36 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: false
+  - name: v2
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: false
+  - name: v3
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
+    served: true
+    storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -12455,6 +12485,26 @@ spec:
       storage: true
       subresources:
         status: {}
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: false
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -16026,6 +16076,36 @@ spec:
           specReplicasPath: .spec.replicas
           statusReplicasPath: .status.replicas
         status: {}
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: false
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: false
+    - name: v3
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -23803,6 +23883,26 @@ spec:
       storage: true
       subresources:
         status: {}
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: false
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -27713,6 +27813,16 @@ spec:
       storage: true
       subresources:
         status: {}
+    - name: v3
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: false
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -31710,4 +31820,34 @@ spec:
           specReplicasPath: .spec.replicas
           statusReplicasPath: .status.replicas
         status: {}
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: false
+    - name: v2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: false
+    - name: v3
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              type: string
+          type: object
+          x-kubernetes-preserve-unknown-fields: true
+      served: true
+      storage: false
 ---


### PR DESCRIPTION
When the cluster contains older CRD, the CRD replace method doesn't work when new CRDs don't contains older CRD version. ( can be without schema ) 