### PR TITLE
fixed ocp client and ocp token getting in prometheus for some scenario

### DIFF
--- a/system-x/services/prometheus-metrics/src/main/java/software/tnb/prometheus/metrics/resource/openshift/OpenshiftPrometheusMetrics.java
+++ b/system-x/services/prometheus-metrics/src/main/java/software/tnb/prometheus/metrics/resource/openshift/OpenshiftPrometheusMetrics.java
@@ -23,9 +23,10 @@ public class OpenshiftPrometheusMetrics extends PrometheusMetrics implements Ope
 
     @Override
     public void beforeAll(ExtensionContext context) throws Exception {
-        Route route = OpenshiftClient.get(OPENSHIFT_MONITORING_NS).getRoute(THANOS_OCP_NAME);
+        Route route = OpenshiftClient.get().inNamespace(OPENSHIFT_MONITORING_NS).routes().withName(THANOS_OCP_NAME)
+                .get();
         String url = "https://" + route.getSpec().getHost();
-        String token = OpenshiftClient.get().authorization().getConfiguration().getOauthToken();
+        String token = OpenshiftClient.get().getOauthToken();
         LOG.info("Prometheus url: {}", url);
         validation = new PrometheusMetricsValidation(url, token, OpenshiftClient.get().getNamespace());
     }


### PR DESCRIPTION
Fixed an issue occurring in the prometheus-metrics module when the openshift cluster was selected by properties (ocp url and credentials). Added a method to obtain ocp access token which takes into account all the possible scenarios.