### PR TITLE
added retry policy to the hyperfoil client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,7 @@
         <gpg.plugin.version>3.0.1</gpg.plugin.version>
         <git.changelog.maven.plugin>1.95.2</git.changelog.maven.plugin>
         <okhttp-version>4.10.0</okhttp-version>
+        <failsafe-version>3.3.0</failsafe-version>
         <gson-version>2.10</gson-version>
     </properties>
 
@@ -143,6 +144,11 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.failsafe</groupId>
+                <artifactId>failsafe-okhttp</artifactId>
+                <version>${failsafe-version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/system-x/services/hyperfoil/pom.xml
+++ b/system-x/services/hyperfoil/pom.xml
@@ -29,6 +29,10 @@
             <artifactId>okhttp</artifactId>
         </dependency>
         <dependency>
+            <groupId>dev.failsafe</groupId>
+            <artifactId>failsafe-okhttp</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>logging-interceptor</artifactId>
         </dependency>

--- a/system-x/services/hyperfoil/src/main/java/software/tnb/hyperfoil/service/HyperfoilConfiguration.java
+++ b/system-x/services/hyperfoil/src/main/java/software/tnb/hyperfoil/service/HyperfoilConfiguration.java
@@ -15,6 +15,11 @@ public class HyperfoilConfiguration extends Configuration {
 
     public static final String HTTP_LOG_ENABLED = "hyperfoil.http.log.enabled";
 
+    public static final String RETRY_BACKOFF_DELAY_IN_SEC = "hyperfoil.http.retry.policy.backoff.delayinsec";
+    public static final String RETRY_BACKOFF_MAX_DELAY_IN_SEC = "hyperfoil.http.retry.policy.backoff.maxdelayinsec";
+    public static final String RETRY_NUMBER_OF_RETRIES = "hyperfoil.http.retry.policy.retries";
+    public static final String RETRY_POLICY_ENABLED = "hyperfoil.http.retry.policy.enabled";
+
     public static boolean keepRunning() {
         return getBoolean(KEEP_RUNNING, false);
     }
@@ -33,5 +38,21 @@ public class HyperfoilConfiguration extends Configuration {
 
     public static boolean isHttpLogEnabled() {
         return getBoolean(HTTP_LOG_ENABLED, false);
+    }
+
+    public static int retryBackoffDelayInSec() {
+        return getInteger(RETRY_BACKOFF_DELAY_IN_SEC, 1);
+    }
+
+    public static int retryBackoffMaxDelayInSec() {
+        return getInteger(RETRY_BACKOFF_MAX_DELAY_IN_SEC, 30);
+    }
+
+    public static int retryNumberOfRetries() {
+        return getInteger(RETRY_NUMBER_OF_RETRIES, 10);
+    }
+
+    public static boolean isRetryPolicyEnabled() {
+        return getBoolean(RETRY_POLICY_ENABLED, false);
     }
 }

--- a/system-x/services/hyperfoil/src/main/java/software/tnb/hyperfoil/validation/ApiClientWithRetryPolicy.java
+++ b/system-x/services/hyperfoil/src/main/java/software/tnb/hyperfoil/validation/ApiClientWithRetryPolicy.java
@@ -1,0 +1,73 @@
+package software.tnb.hyperfoil.validation;
+
+import software.tnb.hyperfoil.service.HyperfoilConfiguration;
+import software.tnb.hyperfoil.validation.generated.ApiClient;
+import software.tnb.hyperfoil.validation.generated.ApiException;
+import software.tnb.hyperfoil.validation.generated.ApiResponse;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.time.temporal.ChronoUnit;
+
+import dev.failsafe.RetryPolicy;
+import dev.failsafe.okhttp.FailsafeCall;
+import okhttp3.Call;
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+
+/**
+ * Version of apiClient supporting a retry policy for sync calls.
+ * The async calls work whithout any retry policy.
+ * 
+ */
+public class ApiClientWithRetryPolicy extends ApiClient {
+
+    public ApiClientWithRetryPolicy() {
+        super();
+    }
+
+    /**
+     * Basic constructor with custom OkHttpClient
+     *
+     * @param client a {@link okhttp3.OkHttpClient} object
+     */
+    public ApiClientWithRetryPolicy(OkHttpClient client) {
+        super(client);
+    }
+
+    /**
+     * Execute HTTP call and deserialize the HTTP response body into the given return type.
+     * A <b>retry policy</b> is applied for failures throwing <i>SocketException</i> or 
+     * <i>SocketTimeoutException</i>. If you don't specify default values for the 
+     * <i>retry policy</i>, default ones will be used. For custom values look to 
+     * {@link software.tnb.hyperfoil.service.Configuration}
+     * 
+     * @see software.tnb.hyperfoil.service.Configuration
+     * @param returnType The return type used to deserialize HTTP response body
+     * @param <T> The return type corresponding to (same with) returnType
+     * @param call Call
+     * @return ApiResponse object containing response status, headers and
+     * data, which is a Java object deserialized from response body and would be null
+     * when returnType is null.
+     * @throws ApiException If fail to execute the call
+     */
+    @Override
+    public <T> ApiResponse<T> execute(Call call, Type returnType) throws ApiException {
+        try {
+            RetryPolicy<Response> retryPolicy = RetryPolicy.<Response>builder()
+                    .handle(SocketException.class, SocketTimeoutException.class)
+                    .withBackoff(HyperfoilConfiguration.retryBackoffDelayInSec(),
+                            HyperfoilConfiguration.retryBackoffMaxDelayInSec(), ChronoUnit.SECONDS)
+                    .withMaxRetries(HyperfoilConfiguration.retryNumberOfRetries()).build();
+            FailsafeCall failsafeCall = FailsafeCall.with(retryPolicy).compose(call);
+            Response response = failsafeCall.execute();
+            T data = handleResponse(response, returnType);
+            return new ApiResponse<T>(response.code(), response.headers().toMultimap(), data);
+        } catch (IOException e) {
+            throw new ApiException(e);
+        }
+    }
+    
+}

--- a/system-x/services/hyperfoil/src/main/java/software/tnb/hyperfoil/validation/HyperfoilValidation.java
+++ b/system-x/services/hyperfoil/src/main/java/software/tnb/hyperfoil/validation/HyperfoilValidation.java
@@ -48,7 +48,9 @@ public class HyperfoilValidation {
         if (HyperfoilConfiguration.isHttpLogEnabled()) {
             okHttpClientBuilder.log();
         }
-        ApiClient apiClient = new ApiClient(okHttpClientBuilder.build());
+        ApiClient apiClient = !HyperfoilConfiguration.isRetryPolicyEnabled()
+                ? new ApiClient(okHttpClientBuilder.build())
+                : new ApiClientWithRetryPolicy(okHttpClientBuilder.build());
         apiClient.setBasePath(basePath);
         apiClient.setVerifyingSsl(false);
         defaultApi = new DefaultApi(apiClient);


### PR DESCRIPTION
Added retry policy to the hyperfoil client to make the client more resilient, especially when the cluster during a test is under stress and in all cases where the connection with the hyperfoil controller could become unstable.