### PR TITLE
retry policy in some commands for knative installation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,11 @@
                 <artifactId>failsafe-okhttp</artifactId>
                 <version>${failsafe-version}</version>
             </dependency>
+            <dependency>
+                <groupId>dev.failsafe</groupId>
+                <artifactId>failsafe</artifactId>
+                <version>${failsafe-version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/system-x/services/knative/pom.xml
+++ b/system-x/services/knative/pom.xml
@@ -13,4 +13,10 @@
     <version>1.0-SNAPSHOT</version>
     <name>TNB :: System-X :: Services :: Knative</name>
 
+    <dependencies>
+        <dependency>
+            <groupId>dev.failsafe</groupId>
+            <artifactId>failsafe</artifactId>
+        </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
In my personal experience knative installation fails 50% of the times. The problem sounds like to be related to library we use to connect to the cluster, because some timeout settings in his code are too low. Using a retry policy in a few points of the knative installation the above issue seems to be fixed.