### PR TITLE
[Saga] Fix duplicate dependency on quarkus

### DIFF
--- a/fuse-products/src/main/java/software/tnb/product/customizer/component/saga/SagaLRACustomizer.java
+++ b/fuse-products/src/main/java/software/tnb/product/customizer/component/saga/SagaLRACustomizer.java
@@ -1,7 +1,6 @@
 package software.tnb.product.customizer.component.saga;
 
 import software.tnb.product.customizer.component.rest.RestCustomizer;
-import software.tnb.product.util.maven.Maven;
 
 import java.util.Map;
 
@@ -20,7 +19,6 @@ public class SagaLRACustomizer extends RestCustomizer {
         getIntegrationBuilder().addToProperties("quarkus.http.root-path", "/camel");
         getIntegrationBuilder().addToProperties(getCommonProperties());
         getIntegrationBuilder().dependencies("lra");
-        getIntegrationBuilder().dependencies(Maven.createDependency("io.quarkus:quarkus-resteasy"));
     }
 
     @Override


### PR DESCRIPTION
seems like `quarkus-resteasy-reactive` is added automatically, so there is no need to add `quarkus-resteasy`, as it will fail with: 

```
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:2.13.5.Final-redhat-00003:build (default) on project saga-lra-comp: Failed to build quarkus application: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
[ERROR] 	[error]: Build step io.quarkus.deployment.steps.CapabilityAggregationStep#aggregateCapabilities threw an exception: java.lang.IllegalStateException: Please make sure there is only one provider of the following capabilities:
[ERROR] capability io.quarkus.rest is provided by:
[ERROR]   - io.quarkus:quarkus-resteasy-reactive:2.13.5.Final-redhat-00003
[ERROR]   - io.quarkus:quarkus-resteasy:2.13.5.Final-redhat-00003
```