### PR TITLE
✨ Allow CSB application to be built or ran

### DIFF
--- a/fuse-products/src/main/java/software/tnb/product/application/App.java
+++ b/fuse-products/src/main/java/software/tnb/product/application/App.java
@@ -49,6 +49,10 @@ public abstract class App {
         }
     }
 
+    protected boolean shouldRun() {
+        return true;
+    }
+
     public abstract void start();
 
     public abstract void stop();
@@ -78,8 +82,10 @@ public abstract class App {
     }
 
     public void waitUntilReady() {
-        WaitUtils.waitFor(() -> isReady() && isCamelStarted(), this::isFailed, 1000L, "Waiting until the integration " + name + " is running");
-        started = true;
+        if (shouldRun()) {
+            WaitUtils.waitFor(() -> isReady() && isCamelStarted(), this::isFailed, 1000L, "Waiting until the integration " + name + " is running");
+            started = true;
+        }
     }
 
     private boolean isCamelStarted() {

--- a/fuse-products/src/main/java/software/tnb/product/csb/application/OpenshiftSpringBootApp.java
+++ b/fuse-products/src/main/java/software/tnb/product/csb/application/OpenshiftSpringBootApp.java
@@ -1,6 +1,5 @@
 package software.tnb.product.csb.application;
 
-import software.tnb.common.config.OpenshiftConfiguration;
 import software.tnb.common.config.TestConfiguration;
 import software.tnb.common.openshift.OpenshiftClient;
 import software.tnb.product.deploystrategy.OpenshiftDeployStrategyFactory;
@@ -16,7 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
+import java.util.stream.Collectors;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.internal.readiness.Readiness;
@@ -67,7 +66,8 @@ public class OpenshiftSpringBootApp extends SpringBootApp {
     @Override
     public boolean isReady() {
         try {
-            final List<Pod> pods = OpenshiftClient.get().getLabeledPods(Map.of(OpenshiftConfiguration.openshiftDeploymentLabel(), finalName));
+            final List<Pod> pods = OpenshiftClient.get().getPods().stream()
+                .filter(deploymentStrategy.podSelector()).collect(Collectors.toList());
             return !pods.isEmpty() && pods.stream()
                 .filter(pod -> !pod.isMarkedForDeletion())
                 .filter(pod -> !"Evicted".equals(pod.getStatus().getReason()))

--- a/fuse-products/src/main/java/software/tnb/product/csb/integration/builder/SpringBootIntegrationBuilder.java
+++ b/fuse-products/src/main/java/software/tnb/product/csb/integration/builder/SpringBootIntegrationBuilder.java
@@ -9,6 +9,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,6 +21,7 @@ import java.util.List;
  */
 public final class SpringBootIntegrationBuilder extends AbstractMavenGitIntegrationBuilder<SpringBootIntegrationBuilder> {
     private final List<Resource> xmlCamelContext = new ArrayList<>();
+    private Path existingJar;
 
     public SpringBootIntegrationBuilder(String integrationName) {
         super(integrationName);
@@ -44,5 +46,14 @@ public final class SpringBootIntegrationBuilder extends AbstractMavenGitIntegrat
 
     public List<Resource> getXmlCamelContext() {
         return xmlCamelContext;
+    }
+
+    public Path getExistingJar() {
+        return existingJar;
+    }
+
+    public SpringBootIntegrationBuilder useExistingJar(Path existingJar) {
+        this.existingJar = existingJar;
+        return buildProject(false); //avoid build if an existing file is used
     }
 }

--- a/fuse-products/src/main/java/software/tnb/product/integration/builder/AbstractGitIntegrationBuilder.java
+++ b/fuse-products/src/main/java/software/tnb/product/integration/builder/AbstractGitIntegrationBuilder.java
@@ -8,6 +8,8 @@ public abstract class AbstractGitIntegrationBuilder<SELF extends AbstractGitInte
     private String branch = "main";
 
     private boolean cleanBeforeBuild = true;
+    private boolean buildProject = true;
+    private boolean runApplication = true;
 
     public AbstractGitIntegrationBuilder(String integrationName) {
         super(integrationName);
@@ -38,6 +40,16 @@ public abstract class AbstractGitIntegrationBuilder<SELF extends AbstractGitInte
         return self();
     }
 
+    /**
+     * If the project is just checked out
+     * @param buildProject boolean, true if the project has been built, false otherwise, default true
+     * @return self instance
+     */
+    public SELF buildProject(boolean buildProject) {
+        this.buildProject = buildProject;
+        return self();
+    }
+
     public String getRepositoryUrl() {
         return repositoryUrl;
     }
@@ -52,5 +64,23 @@ public abstract class AbstractGitIntegrationBuilder<SELF extends AbstractGitInte
 
     public boolean cleanBeforeBuild() {
         return this.cleanBeforeBuild;
+    }
+
+    public boolean buildProject() {
+        return buildProject;
+    }
+
+    /**
+     * If the application should run after build
+     * @param runApplication
+     * @return self instance
+     */
+    public SELF runApplication(boolean runApplication) {
+        this.runApplication = runApplication;
+        return self();
+    }
+
+    public boolean runApplication() {
+        return runApplication;
     }
 }


### PR DESCRIPTION
There are some CSB examples that need to be built before running the sub-modules, so there would be a way to build without running applications and running integration application without build it (since it is already built) 