### PR TITLE
Disable Maven transfer progress

### DIFF
--- a/fuse-products/src/main/java/software/tnb/product/util/maven/Maven.java
+++ b/fuse-products/src/main/java/software/tnb/product/util/maven/Maven.java
@@ -134,6 +134,7 @@ public class Maven {
             .setBatchMode(true)
             .setGoals(goals)
             .setProperties(properties)
+            .setNoTransferProgress(true)
             .setOutputHandler(buildRequest.getOutputHandler())
             .setErrorHandler(buildRequest.getOutputHandler());
 


### PR DESCRIPTION
* Less boilerplate in log output
* Faster builds