### PR TITLE
💚 Allows execution using testcontainers+podman

### DIFF
--- a/fuse-products/src/main/java/software/tnb/product/junit/SkipOnPodman.java
+++ b/fuse-products/src/main/java/software/tnb/product/junit/SkipOnPodman.java
@@ -1,0 +1,16 @@
+package software.tnb.product.junit;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Target({TYPE, METHOD})
+@Retention(RUNTIME)
+@DisabledIfEnvironmentVariable(named = "DOCKER_HOST", matches = ".*podman.*", disabledReason = "The test doesn't support Podman")
+public @interface SkipOnPodman {
+}

--- a/system-x/services/kafka/src/main/java/software/tnb/kafka/resource/local/StrimziContainer.java
+++ b/system-x/services/kafka/src/main/java/software/tnb/kafka/resource/local/StrimziContainer.java
@@ -29,7 +29,7 @@ public class StrimziContainer extends GenericContainer<StrimziContainer> {
 
         String listenerAddress = "localhost";
         String dockerHost = TestcontainersConfiguration.getInstance().getEnvironment().get("DOCKER_HOST");
-        if (dockerHost != null) {
+        if (dockerHost != null && dockerHost.contains("tcp://")) {
             listenerAddress = StringUtils.substringBetween(dockerHost, "tcp://", ":");
         }
         addFixedExposedPort(KAFKA_PORT, KAFKA_PORT);


### PR DESCRIPTION
- Adds `@SkipOnPodman` annotation to avoid to execute tests on Podman, since there are some network issues using testcontainers+podman
- Fixes Strimzi container on `DOCKER_HOST` valued with unix socket uri