### PR TITLE
Cleanup scc and sa from OpenShift deployments

### DIFF
--- a/system-x/services/snmp/src/main/java/software/tnb/snmp/resource/openshift/OpenshiftSnmp.java
+++ b/system-x/services/snmp/src/main/java/software/tnb/snmp/resource/openshift/OpenshiftSnmp.java
@@ -34,6 +34,8 @@ public class OpenshiftSnmp extends SnmpServer implements ReusableOpenshiftDeploy
     @Override
     public void undeploy() {
         LOG.info("Undeploying SNMP server");
+        OpenshiftClient.get().securityContextConstraints().withName(sccName).delete();
+        OpenshiftClient.get().serviceAccounts().withName(serviceAccountName).delete();
         OpenshiftClient.get().deploymentConfigs().withName(name()).delete();
         OpenshiftClient.get().services().withLabel(OpenshiftConfiguration.openshiftDeploymentLabel(), name()).delete();
         WaitUtils.waitFor(() -> servicePod() == null, "Waiting until the pod is removed");


### PR DESCRIPTION
Not sure if it was intended but I noticed SCCs still present on our s390x clusters after test runs. Adding cleanup for scc and sa similar to the other OpenShift service deployments.