### PR TITLE
Add option to skip setup of CK IntegrationPlatform

### DIFF
--- a/fuse-products/src/main/java/software/tnb/product/ck/CamelK.java
+++ b/fuse-products/src/main/java/software/tnb/product/ck/CamelK.java
@@ -118,44 +118,46 @@ public class CamelK extends OpenshiftProduct implements KameletOps, BeforeEachCa
             }
         }
 
-        ObjectMeta metadata = new ObjectMetaBuilder()
-            .withName(config.integrationPlatformName())
-            .withLabels(Map.of("app", "camel-k"))
-            .build();
+        if (config.skipIPSetup()) {
+            ObjectMeta metadata = new ObjectMetaBuilder()
+                .withName(config.integrationPlatformName())
+                .withLabels(Map.of("app", "camel-k"))
+                .build();
 
-        IntegrationPlatformSpec spec = new IntegrationPlatformSpec();
+            IntegrationPlatformSpec spec = new IntegrationPlatformSpec();
 
-        Build build = new Build();
-        build.setTimeout(config.mavenBuildTimeout() + "m");
-        spec.setBuild(build);
-        if (config.baseImage() != null) {
-            build.setBaseImage(config.baseImage());
+            Build build = new Build();
+            build.setTimeout(config.mavenBuildTimeout() + "m");
+            spec.setBuild(build);
+            if (config.baseImage() != null) {
+                build.setBaseImage(config.baseImage());
+            }
+
+            org.apache.camel.v1.integrationplatformspec.build.Maven maven = new org.apache.camel.v1.integrationplatformspec.build.Maven();
+            Settings settings = new Settings();
+            ConfigMapKeyRef cm = new ConfigMapKeyRef();
+            cm.setKey("settings.xml");
+            cm.setName(config.mavenSettingsConfigMapName());
+            cm.setOptional(false);
+            settings.setConfigMapKeyRef(cm);
+            maven.setSettings(settings);
+
+            build.setMaven(maven);
+
+            IntegrationPlatform ip = new IntegrationPlatform();
+            ip.setMetadata(metadata);
+            ip.setSpec(spec);
+
+            if (TestConfiguration.mavenSettings() == null) {
+                OpenshiftClient.get().createConfigMap(config.mavenSettingsConfigMapName(), Map.of("settings.xml", Maven.createSettingsXmlFile()));
+            } else {
+                OpenshiftClient.get().createConfigMap(config.mavenSettingsConfigMapName(),
+                    Map.of("settings.xml", IOUtils.readFile(Paths.get(TestConfiguration.mavenSettings()))));
+            }
+
+            OpenshiftClient.get().resources(IntegrationPlatform.class).delete();
+            OpenshiftClient.get().resources(IntegrationPlatform.class).resource(ip).create();
         }
-
-        org.apache.camel.v1.integrationplatformspec.build.Maven maven = new org.apache.camel.v1.integrationplatformspec.build.Maven();
-        Settings settings = new Settings();
-        ConfigMapKeyRef cm = new ConfigMapKeyRef();
-        cm.setKey("settings.xml");
-        cm.setName(config.mavenSettingsConfigMapName());
-        cm.setOptional(false);
-        settings.setConfigMapKeyRef(cm);
-        maven.setSettings(settings);
-
-        build.setMaven(maven);
-
-        IntegrationPlatform ip = new IntegrationPlatform();
-        ip.setMetadata(metadata);
-        ip.setSpec(spec);
-
-        if (TestConfiguration.mavenSettings() == null) {
-            OpenshiftClient.get().createConfigMap(config.mavenSettingsConfigMapName(), Map.of("settings.xml", Maven.createSettingsXmlFile()));
-        } else {
-            OpenshiftClient.get().createConfigMap(config.mavenSettingsConfigMapName(),
-                Map.of("settings.xml", IOUtils.readFile(Paths.get(TestConfiguration.mavenSettings()))));
-        }
-
-        OpenshiftClient.get().resources(IntegrationPlatform.class).delete();
-        OpenshiftClient.get().resources(IntegrationPlatform.class).resource(ip).create();
 
         if (TestConfiguration.streamLogs()) {
             setupLogger();

--- a/fuse-products/src/main/java/software/tnb/product/ck/CamelK.java
+++ b/fuse-products/src/main/java/software/tnb/product/ck/CamelK.java
@@ -118,7 +118,7 @@ public class CamelK extends OpenshiftProduct implements KameletOps, BeforeEachCa
             }
         }
 
-        if (config.skipIPSetup()) {
+        if (!config.skipIPSetup()) {
             ObjectMeta metadata = new ObjectMetaBuilder()
                 .withName(config.integrationPlatformName())
                 .withLabels(Map.of("app", "camel-k"))

--- a/fuse-products/src/main/java/software/tnb/product/ck/configuration/CamelKConfiguration.java
+++ b/fuse-products/src/main/java/software/tnb/product/ck/configuration/CamelKConfiguration.java
@@ -16,6 +16,8 @@ public abstract class CamelKConfiguration extends CamelConfiguration {
     public static final String INTEGRATION_PLATFORM_NAME = "camelk.integration.platform.name";
     public static final String BASE_IMAGE = "camelk.base.image";
 
+    public static final String SKIP_IP_SETUP = "camelk.skip.ip.setup";
+
     public String subscriptionName() {
         return "tnb-camel-k";
     }
@@ -54,6 +56,10 @@ public abstract class CamelKConfiguration extends CamelConfiguration {
 
     public boolean useGlobalInstallation() {
         return getBoolean(USE_GLOBAL_INSTALLATION, false);
+    }
+
+    public boolean skipIPSetup() {
+        return getBoolean(SKIP_IP_SETUP, false);
     }
 
     public static CamelKConfiguration getConfiguration() {


### PR DESCRIPTION
Usage: `-Dcamelk.skip.ip.setup=true` to avoid modifications of IntegrationPlatform of installed CK operator