### PR TITLE
[CSB-3412] Add IBM MQ SSL configuration for local container

### DIFF
--- a/system-x/services/jms/ibm-mq/src/main/java/software/tnb/jms/ibm/mq/resource/local/IBMMQContainer.java
+++ b/system-x/services/jms/ibm-mq/src/main/java/software/tnb/jms/ibm/mq/resource/local/IBMMQContainer.java
@@ -6,18 +6,42 @@ import software.tnb.jms.ibm.mq.service.IBMMQ;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 public class IBMMQContainer extends GenericContainer<IBMMQContainer> {
     private static final Path mqscCommandFilePath = Paths.get("target/" + IBMMQ.MQSC_COMMAND_FILE_NAME);
+    private static final Path keysFolderPath = Paths.get("target/keys");
 
-    public IBMMQContainer(String image, int port, Map<String, String> env, String mqsc) {
+    public IBMMQContainer(String image, int port, Map<String, String> env, String mqsc, Path privateKey, Path publicKey) {
         super(image);
         createLocalMqscCommandFile(mqsc);
         withExposedPorts(port);
         withFileSystemBind(mqscCommandFilePath.toAbsolutePath().toString(), IBMMQ.MQSC_COMMAND_FILES_LOCATION + "/" + IBMMQ.MQSC_COMMAND_FILE_NAME);
+
+        if (Objects.nonNull(privateKey) && Objects.nonNull(publicKey)) {
+            try {
+                Files.createDirectories(keysFolderPath);
+                final Path keyFile = Paths.get(keysFolderPath.toAbsolutePath().toString(), "key.key");
+                Files.copy(privateKey, keyFile);
+                final Path certFile = Paths.get(keysFolderPath.toAbsolutePath().toString(), "key.crt");
+                Files.copy(publicKey, certFile);
+                Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rw-r--r--");
+                Files.setPosixFilePermissions(keyFile, perms);
+                Files.setPosixFilePermissions(certFile, perms);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            withFileSystemBind(keysFolderPath.toAbsolutePath().toString(), IBMMQ.KEYS_FOLDER);
+        }
+
         withEnv(env);
         // AMQ5806I is a message code for queue manager start
         waitingFor(Wait.forLogMessage(".*AMQ5806I.*", 1));

--- a/system-x/services/jms/ibm-mq/src/main/java/software/tnb/jms/ibm/mq/resource/local/LocalIBMMQ.java
+++ b/system-x/services/jms/ibm-mq/src/main/java/software/tnb/jms/ibm/mq/resource/local/LocalIBMMQ.java
@@ -5,8 +5,11 @@ import software.tnb.jms.ibm.mq.service.IBMMQ;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.images.builder.Transferable;
 
 import com.google.auto.service.AutoService;
+
+import java.io.IOException;
 
 @AutoService(IBMMQ.class)
 public class LocalIBMMQ extends IBMMQ implements Deployable {
@@ -16,8 +19,10 @@ public class LocalIBMMQ extends IBMMQ implements Deployable {
     @Override
     public void deploy() {
         LOG.info("Starting IBM MQ container");
-        container = new IBMMQContainer(image(), DEFAULT_PORT, containerEnvironment(), mqscConfig());
+        container = new IBMMQContainer(image(), DEFAULT_PORT, containerEnvironment(), mqscConfig()
+            , getConfiguration().keyPath(), getConfiguration().certPath());
         container.start();
+        generateKeystore();
         LOG.info("IBM MQ container started");
     }
 
@@ -41,5 +46,28 @@ public class LocalIBMMQ extends IBMMQ implements Deployable {
     @Override
     protected String clientHostname() {
         return host();
+    }
+
+    protected void generateKeystore() {
+        if (getConfiguration().useSSL()) {
+            try {
+                final String sslFolder = String.format(IBMMQ.SSL_FOLDER, account().queueManager());
+                final String kdbFile = sslFolder + "/key";
+                final String certLabel = account().queueManager() + ".cert";
+
+                LOG.debug(container.execInContainer("runmqakm", "-keydb", "-create", "-db"
+                    , kdbFile + ".kdb", "-pw", account().password()
+                    , "-type", "pkcs12", "-expire", "1000", "-stash").toString());
+
+                LOG.debug(container.execInContainer("runmqakm", "-cert", "-add", "-label", certLabel, "-db", kdbFile + ".kdb"
+                    , "-stashed", "-trust", "enable", "-file", IBMMQ.KEYS_FOLDER + "/key.crt").toString());
+
+                String cmd = "REFRESH SECURITY(*) TYPE(SSL)\n";
+                container.copyFileToContainer(Transferable.of(cmd), "/tmp/ssl.in");
+                LOG.debug(container.execInContainer("runmqsc", "-f", "/tmp/ssl.in", account().queueManager()).toString());
+            } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 }

--- a/system-x/services/jms/ibm-mq/src/main/java/software/tnb/jms/ibm/mq/service/configuration/IBMMQConfiguration.java
+++ b/system-x/services/jms/ibm-mq/src/main/java/software/tnb/jms/ibm/mq/service/configuration/IBMMQConfiguration.java
@@ -1,0 +1,40 @@
+package software.tnb.jms.ibm.mq.service.configuration;
+
+import software.tnb.common.service.configuration.ServiceConfiguration;
+
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class IBMMQConfiguration extends ServiceConfiguration {
+
+    private static final String KEY_PATH = "KEY_PATH";
+    private static final String CERT_PATH = "CERT_PATH";
+    private static final String USE_SSL = "USE_SSL";
+
+    public IBMMQConfiguration withKeyPath(Path value) {
+        set(KEY_PATH, value.toAbsolutePath().toString());
+        return this;
+    }
+
+    public IBMMQConfiguration withCertPath(Path value) {
+        set(CERT_PATH, value.toAbsolutePath().toString());
+        return this;
+    }
+
+    public IBMMQConfiguration useSSL(boolean value) {
+        set(USE_SSL, value);
+        return this;
+    }
+
+    public boolean useSSL() {
+        return Optional.ofNullable(get(USE_SSL, Boolean.class)).orElse(Boolean.FALSE);
+    }
+
+    public Path certPath() {
+        return Optional.ofNullable(get(CERT_PATH, String.class)).map(Path::of).orElse(null);
+    }
+
+    public Path keyPath() {
+        return Optional.ofNullable(get(KEY_PATH, String.class)).map(Path::of).orElse(null);
+    }
+}


### PR DESCRIPTION
Adds the feature to run the IBM MQ container with custom SSL that can be used also in JMS connection

```
ServiceFactory.create(IBMMQ.class, conf -> conf.useSSL(true)
 .withKeyPath(Path.of("[path to private key]"))
 .withCertPath(Path.of("[path to public key]")))
```

currently is supported only on local execution