### PR TITLE
✨ Adds Kudu on OCP service

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -301,6 +301,11 @@
             </dependency>
             <dependency>
                 <groupId>software.tnb</groupId>
+                <artifactId>system-x-kudu</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>software.tnb</groupId>
                 <artifactId>system-x-ldap</artifactId>
                 <version>1.0-SNAPSHOT</version>
             </dependency>

--- a/system-x/services/kudu/pom.xml
+++ b/system-x/services/kudu/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>software.tnb</groupId>
+        <artifactId>system-x-services</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>system-x-kudu</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>TNB :: System-X :: Services :: Kudu</name>
+
+    <properties>
+        <kudu-client.version>1.17.0</kudu-client.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.kudu</groupId>
+                <artifactId>kudu-client</artifactId>
+                <version>${kudu-client.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kudu</groupId>
+            <artifactId>kudu-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/system-x/services/kudu/src/main/java/software/tnb/kudu/resource/client/KuduClient.java
+++ b/system-x/services/kudu/src/main/java/software/tnb/kudu/resource/client/KuduClient.java
@@ -1,0 +1,16 @@
+package software.tnb.kudu.resource.client;
+
+import java.io.Closeable;
+import java.util.List;
+import java.util.Map;
+
+public interface KuduClient extends Closeable {
+
+    String findLeaderMasterServer();
+
+    boolean tableExists(String tableName);
+
+    void createTable(Map<String, Object> tableDefinition);
+
+    List<String> listRows(String tableName, List<String> columns, String predicates);
+}

--- a/system-x/services/kudu/src/main/java/software/tnb/kudu/resource/openshift/OpenshiftKudu.java
+++ b/system-x/services/kudu/src/main/java/software/tnb/kudu/resource/openshift/OpenshiftKudu.java
@@ -1,0 +1,379 @@
+package software.tnb.kudu.resource.openshift;
+
+import software.tnb.common.config.OpenshiftConfiguration;
+import software.tnb.common.deployment.OpenshiftDeployable;
+import software.tnb.common.deployment.WithInClusterHostname;
+import software.tnb.common.openshift.OpenshiftClient;
+import software.tnb.common.utils.WaitUtils;
+import software.tnb.kudu.service.Kudu;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.auto.service.AutoService;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarSource;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.ObjectFieldSelector;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.ProbeBuilder;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
+import io.fabric8.kubernetes.client.readiness.Readiness;
+import io.fabric8.openshift.api.model.RouteBuilder;
+
+@AutoService(Kudu.class)
+public class OpenshiftKudu extends Kudu implements OpenshiftDeployable, WithInClusterHostname {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenshiftKudu.class);
+
+    private final List<String> hostNames = List.of(MASTER_PREFIX, TSERVER_PREFIX);
+    private static final String KUDU_CLIENT = "kudu-client";
+
+    @Override
+    public void openResources() {
+        client = new RemoteClient(getMastersUsingRpc(), getClientPodName());
+        LOG.debug("master leader {}", client.findLeaderMasterServer());
+        createUIRoute();
+    }
+
+    private String getClientPodName() {
+        return OpenshiftClient.get().pods().withLabel(OpenshiftConfiguration.openshiftDeploymentLabel(), KUDU_CLIENT)
+            .list().getItems().stream().filter(Readiness::isPodReady).map(p -> p.getMetadata().getName())
+            .findAny().orElseThrow(() -> new IllegalStateException("unable to find a ready client pod"));
+    }
+
+    @Override
+    public void closeResources() {
+        if (client != null) {
+            try {
+                client.close();
+                client = null;
+            } catch (IOException e) {
+                LOG.warn("unable to close the client");
+            }
+        }
+    }
+
+    @Override
+    public void create() {
+        createServices();
+        createStatefulSet();
+        createClient();
+    }
+
+    @Override
+    public boolean isDeployed() {
+        return OpenshiftClient.get().getStatefulSet(MASTER_PREFIX) != null
+            && OpenshiftClient.get().getStatefulSet(TSERVER_PREFIX) != null
+            && servicePods().size() == getConfiguration().masterNumber() + getConfiguration().tabletNumber();
+    }
+
+    @Override
+    public Predicate<Pod> podSelector() {
+        return pod -> pod.getMetadata().getLabels().entrySet().stream()
+            .anyMatch(e -> e.getKey().equals(OpenshiftConfiguration.openshiftDeploymentLabel())
+            && (MASTER_PREFIX.equals(e.getValue()) || TSERVER_PREFIX.equals(e.getValue()) || KUDU_CLIENT.equals(e.getValue())));
+    }
+
+    @Override
+    public void undeploy() {
+        LOG.debug("Delete deployment {}", KUDU_CLIENT);
+        OpenshiftClient.get().apps().deployments().withName(KUDU_CLIENT).delete();
+
+        LOG.debug("Delete route with label {}={}", OpenshiftConfiguration.openshiftDeploymentLabel(), MASTER_PREFIX);
+        OpenshiftClient.get().routes().withLabel(OpenshiftConfiguration.openshiftDeploymentLabel(), MASTER_PREFIX).delete();
+
+        hostNames.forEach(label -> {
+            LOG.debug("Delete stateful set {}", label);
+            OpenshiftClient.get().apps().statefulSets().withName(label).delete();
+            LOG.debug("Delete services with label {}={}", OpenshiftConfiguration.openshiftDeploymentLabel(), label);
+            OpenshiftClient.get().services().withLabel(OpenshiftConfiguration.openshiftDeploymentLabel(), label).delete();
+        });
+
+        WaitUtils.waitFor(() -> OpenshiftClient.get().pods().list().getItems().stream().filter(podSelector()).count() == 0
+            , "Wait for pods terminating");
+    }
+
+    @Override
+    public String inClusterHostname() {
+        return String.join(",", getMastersUsingRpc());
+    }
+
+    @Override
+    public List<String> getMastersUsingHttp() {
+        return IntStream.range(0, getConfiguration().masterNumber())
+            .mapToObj(i -> MASTER_PREFIX + "-" + i + ":" + getPorts(true).get("ui")).toList();
+    }
+
+    @Override
+    public List<String> getTserversUsingHttp() {
+        return IntStream.range(0, getConfiguration().tabletNumber())
+            .mapToObj(i -> TSERVER_PREFIX + "-" + i + ":" + getPorts(false).get("ui")).toList();
+    }
+
+    @Override
+    public List<String> getMastersUsingRpc() {
+        return IntStream.range(0, getConfiguration().masterNumber())
+            .mapToObj(i -> MASTER_PREFIX + "-" + i + ":" + getPorts(true).get("rpc-port")).toList();
+    }
+
+    @Override
+    public List<String> getTserversUsingRpc() {
+        return IntStream.range(0, getConfiguration().tabletNumber())
+            .mapToObj(i -> TSERVER_PREFIX + "-" + i + ":" + getPorts(false).get("rpc-port")).toList();
+    }
+
+    private void createServices() {
+        hostNames.forEach(
+            serviceName -> {
+                boolean isMaster = serviceName.contains("master");
+
+                Map<String, Integer> ports = getPorts(isMaster);
+
+                ServiceSpecBuilder serviceSpecBuilder = new ServiceSpecBuilder().addToSelector(OpenshiftConfiguration.openshiftDeploymentLabel()
+                    , serviceName);
+
+                ports.forEach((key, value) ->
+                    serviceSpecBuilder.addToPorts(new ServicePortBuilder()
+                        .withName(key)
+                        .withPort(value)
+                        .withTargetPort(new IntOrString(value))
+                        .build())
+                );
+
+                LOG.debug("Creating service {}", serviceName);
+                OpenshiftClient.get().services().resource(new ServiceBuilder()
+                    .editOrNewMetadata()
+                    .withName(serviceName)
+                    .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), serviceName)
+                    .endMetadata()
+                    .editOrNewSpecLike(serviceSpecBuilder.build())
+                    .withType("NodePort")
+                    .endSpec()
+                    .build()).serverSideApply();
+            }
+        );
+
+        //create service for single pods of masters
+        IntStream.range(0, getConfiguration().masterNumber()).forEach(i -> {
+            String serviceName = MASTER_PREFIX + "-" + i;
+            LOG.debug("Creating service {}", serviceName);
+            OpenshiftClient.get().services().resource(
+                new ServiceBuilder()
+                    .editOrNewMetadata()
+                        .withName(serviceName)
+                        .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), MASTER_PREFIX)
+                    .endMetadata()
+                    .editOrNewSpecLike(new ServiceSpecBuilder()
+                        .addToSelector("statefulset.kubernetes.io/pod-name"
+                        , serviceName)
+                        .addNewPort()
+                            .withName("rpc-port")
+                            .withPort(getPorts(true).get("rpc-port"))
+                            .withTargetPort(new IntOrString(getPorts(true).get("rpc-port")))
+                        .endPort()
+                        .addNewPort()
+                            .withName("ui")
+                            .withPort(getPorts(true).get("ui"))
+                            .withTargetPort(new IntOrString(getPorts(true).get("ui")))
+                        .endPort()
+                        .build())
+                    .endSpec()
+                    .build()
+            ).serverSideApply();
+        });
+
+        //create service for single pods of tserver
+        IntStream.range(0, getConfiguration().tabletNumber()).forEach(i -> {
+            String serviceName = TSERVER_PREFIX + "-" + i;
+            LOG.debug("Creating service {}", serviceName);
+            OpenshiftClient.get().services().resource(
+                new ServiceBuilder()
+                    .editOrNewMetadata()
+                    .withName(serviceName)
+                    .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), TSERVER_PREFIX)
+                    .endMetadata()
+                    .editOrNewSpecLike(new ServiceSpecBuilder()
+                        .addToSelector("statefulset.kubernetes.io/pod-name"
+                            , serviceName)
+                        .addNewPort()
+                            .withName("rpc-port")
+                            .withPort(getPorts(true).get("rpc-port"))
+                            .withTargetPort(new IntOrString(getPorts(true).get("rpc-port")))
+                        .endPort()
+                        .build())
+                    .endSpec()
+                    .build()
+            ).serverSideApply();
+        });
+    }
+
+    private void createStatefulSet() {
+        hostNames.forEach(
+            statefulSetName -> {
+                boolean isMaster = statefulSetName.contains("master");
+                int replicaNum = isMaster ? getConfiguration().masterNumber() : getConfiguration().tabletNumber();
+                List<ContainerPort> containerPorts = getPorts(isMaster).entrySet().stream()
+                    .map(e -> new ContainerPortBuilder().withName(e.getKey()).withContainerPort(e.getValue()).withProtocol("TCP").build())
+                    .collect(Collectors.toList());
+                String arg = isMaster ? "master" : "tserver";
+                final Probe probe = new ProbeBuilder().editOrNewHttpGet().withPort(new IntOrString(getPorts(isMaster).get("ui")))
+                    .withPath("/healthz").withScheme("HTTP").endHttpGet()
+                    .withInitialDelaySeconds(10)
+                    .withTimeoutSeconds(5)
+                    .withFailureThreshold(10).build();
+
+                EnvVar getHostFrom = new EnvVar("GET_HOSTS_FROM", "dns", null);
+                EnvVar podIp = new EnvVar("POD_IP", null, new EnvVarSource(null
+                    , new ObjectFieldSelector(null, "status.podIP"), null, null));
+                EnvVar podName = new EnvVar("POD_NAME", null, new EnvVarSource(null
+                    , new ObjectFieldSelector(null, "metadata.name"), null, null));
+
+                // @formatter:off
+                LOG.debug("Creating Stateful Set {}", statefulSetName);
+                OpenshiftClient.get().apps().statefulSets().resource(new StatefulSetBuilder()
+                        .editOrNewMetadata()
+                            .withName(statefulSetName)
+                            .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), statefulSetName)
+                        .endMetadata()
+                        .editOrNewSpec()
+                            .withServiceName(statefulSetName)
+                            .withPodManagementPolicy("Parallel")
+                            .withReplicas(replicaNum)
+                            .withNewSelector()
+                                .addToMatchLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), statefulSetName)
+                            .endSelector()
+                            .editOrNewTemplate()
+                                .editOrNewMetadata()
+                                    .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), statefulSetName)
+                                .endMetadata()
+                                .editOrNewSpec()
+                                    .addNewContainer()
+                                        .withName(statefulSetName)
+                                        .withImage(image())
+                                        .withImagePullPolicy("IfNotPresent")
+                                        .addAllToPorts(containerPorts)
+                                        .addAllToEnv(List.of(getHostFrom, podIp, podName))
+                                        .addAllToEnv(containerEnvironment(isMaster).entrySet().stream()
+                                            .map(e -> new EnvVar(e.getKey(), e.getValue(), null))
+                                            .collect(Collectors.toList()))
+                                        .withArgs(arg)
+                                        .withReadinessProbe(probe)
+                                        .withLivenessProbe(probe)
+                                        .addToVolumeMounts(new VolumeMountBuilder()
+                                            .withName("datadir")
+                                            .withMountPath("/var/lib/kudu")
+                                            .build()
+                                        )
+                                    .endContainer()
+                                    .addToVolumes(new VolumeBuilder().withNewEmptyDir().endEmptyDir().withName("datadir").build())
+                                .endSpec()
+                            .endTemplate()
+                        .endSpec()
+                    .build()
+                ).serverSideApply();
+                // @formatter:on
+            }
+        );
+
+    }
+
+    private String createUIRoute() {
+        final String name = "kudu-ui";
+
+        Function<String, Boolean> routeExists = n -> OpenshiftClient.get().routes().withName(n).get() != null;
+
+        if (routeExists.apply(name)) {
+            return name;
+        }
+
+        final String masterService = client.findLeaderMasterServer().split("\\.")[0];
+        LOG.debug("Creating Route {} to {}", name, masterService);
+        // @formatter:off
+        OpenshiftClient.get().routes()
+            .resource(new RouteBuilder()
+            .editOrNewMetadata()
+                .withName(name)
+                .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), MASTER_PREFIX)
+            .endMetadata()
+            .editOrNewSpec()
+                .withNewTo()
+                    .withKind("Service")
+                    .withName(masterService)
+                    .withWeight(100)
+                .endTo()
+                .withNewPort()
+                    .withTargetPort(new IntOrString(getPorts(true).get("ui")))
+                .endPort()
+            .endSpec()
+            .build()
+        ).serverSideApply();
+        // @formatter:on
+
+        WaitUtils.waitFor(() -> routeExists.apply(name), "Waiting for route is created");
+
+        return name;
+    }
+
+    private Map<String, String> containerEnvironment(boolean isMaster) {
+        return Map.of("KUDU_MASTERS", String.join(",", getMastersUsingRpc())
+                , isMaster ? "MASTER_ARGS" : "TSERVER_ARGS"
+                , String.format("--webserver_port=%s --stderrthreshold=0 --use_hybrid_clock=false --unlock_unsafe_flags=true"
+                , getPorts(isMaster).get("ui"))
+            );
+    }
+
+    private static Map<String, Integer> getPorts(boolean isMaster) {
+        return Map.of("ui", isMaster ? MASTER_HTTP_PORT : TSERVER_HTTP_PORT
+            , "rpc-port", isMaster ? MASTER_RPC_PORT : TSERVER_RPC_PORT);
+    }
+
+    private void createClient() {
+        // @formatter:off
+        LOG.debug("Creating deployment for client");
+        OpenshiftClient.get().apps().deployments().resource(new DeploymentBuilder()
+                .editOrNewMetadata()
+                    .withName(KUDU_CLIENT)
+                    .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), KUDU_CLIENT)
+                .endMetadata()
+                .editOrNewSpec()
+                    .withNewSelector()
+                        .addToMatchLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), KUDU_CLIENT)
+                    .endSelector()
+                    .withReplicas(1)
+                    .editOrNewTemplate()
+                        .editOrNewMetadata()
+                            .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), KUDU_CLIENT)
+                        .endMetadata()
+                        .editOrNewSpec()
+                            .addNewContainer()
+                                .withName(KUDU_CLIENT)
+                                .withImage(image())
+                                .withCommand("tail", "-f", "/dev/null")
+                            .endContainer()
+                        .endSpec()
+                    .endTemplate()
+                .endSpec()
+                .build()
+        ).serverSideApply();
+        // @formatter:on
+    }
+}

--- a/system-x/services/kudu/src/main/java/software/tnb/kudu/resource/openshift/RemoteClient.java
+++ b/system-x/services/kudu/src/main/java/software/tnb/kudu/resource/openshift/RemoteClient.java
@@ -1,0 +1,124 @@
+package software.tnb.kudu.resource.openshift;
+
+import software.tnb.common.openshift.OpenshiftClient;
+import software.tnb.kudu.resource.client.KuduClient;
+
+import org.apache.commons.lang3.StringUtils;
+import org.awaitility.Awaitility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import cz.xtf.core.openshift.PodShellOutput;
+
+/**
+ * Run commands in the client POD using <a href=https://kudu.apache.org/docs/command_line_tools_reference.html>Kudu CLI</a>
+ */
+public class RemoteClient implements KuduClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RemoteClient.class);
+
+    private final List<String> masters;
+    private final String clientPodName;
+    private final ObjectMapper mapper;
+
+    private String leader;
+
+    public RemoteClient(List<String> masters, String clientPodName) {
+        this.masters = masters;
+        this.clientPodName = clientPodName;
+        mapper = new ObjectMapper();
+    }
+
+    @Override
+    public String findLeaderMasterServer() {
+        if (leader == null) {
+            Awaitility.await("wait for master leader")
+                .atMost(Duration.ofSeconds(20))
+                .ignoreExceptions()
+                .until(() -> {
+                    final String cmdOut = runCommand("master", "list", "-format=json", getMasters());
+                    if (StringUtils.isBlank(cmdOut)) {
+                        throw new RuntimeException("unable to read leader master");
+                    }
+                    final List<Map> result = mapper.readValue(cmdOut, List.class);
+                    leader = result.stream().filter(row -> "LEADER".equals(row.get("role")))
+                        .map(row -> row.get("rpc-addresses"))
+                        .map(Objects::toString).findFirst()
+                        .orElseThrow(() -> new IllegalStateException("no leader master found"));
+                    return true;
+                });
+        }
+        return leader;
+    }
+
+    @Override
+    public boolean tableExists(String tableName) {
+        final String cmdOut = runCommand("table", "list", "-tables=" + tableName, getMasters());
+        return cmdOut.contains(tableName);
+    }
+
+    @Override
+    public void createTable(Map<String, Object> tableDefinition) {
+        try {
+            runCommand("table", "create", getMasters(), mapper.writeValueAsString(tableDefinition));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public List<String> listRows(String tableName, List<String> columns, String predicates) {
+        final List<String> commands = new ArrayList<>(List.of("table", "scan", getMasters(), tableName));
+        if (columns != null && !columns.isEmpty()) {
+            commands.add("-columns=" + String.join(",", columns));
+        }
+        if (StringUtils.isNotBlank(predicates)) {
+            commands.add("-predicates=" + predicates);
+        }
+        final String cmdOut = runCommand(commands);
+        LOG.debug("table rows:\n{}", cmdOut);
+        return Arrays.stream(cmdOut.split(System.lineSeparator())).filter(line -> line.startsWith("("))
+            .map(line -> line.replaceAll("\\(", ""))
+            .map(line -> line.replaceAll("\\)", ""))
+            .toList();
+    }
+
+    @Override
+    public void close() {
+        leader = null;
+    }
+
+    /**
+     * Run command in POD
+     * @param commands String[], the commands without initial kudu
+     * @return String, output
+     */
+    private String runCommand(final String... commands) {
+        final String[] com = new String[commands.length + 1];
+        com[0] = "kudu";
+        System.arraycopy(commands, 0, com, 1, com.length - 1);
+        final PodShellOutput outCmd = OpenshiftClient.get().podShell(OpenshiftClient.get().getPod(clientPodName)).execute(com);
+        if (StringUtils.isNotBlank(outCmd.getError())) {
+            throw new RuntimeException(outCmd.getError());
+        }
+        return outCmd.getOutput();
+    }
+
+    private String runCommand(final List<String> commands) {
+        return runCommand(commands.toArray(new String[0]));
+    }
+
+    private String getMasters() {
+        return String.join(",", masters);
+    }
+}

--- a/system-x/services/kudu/src/main/java/software/tnb/kudu/service/Kudu.java
+++ b/system-x/services/kudu/src/main/java/software/tnb/kudu/service/Kudu.java
@@ -1,0 +1,44 @@
+package software.tnb.kudu.service;
+
+import software.tnb.common.account.NoAccount;
+import software.tnb.common.deployment.WithDockerImage;
+import software.tnb.common.service.ConfigurableService;
+import software.tnb.kudu.resource.client.KuduClient;
+import software.tnb.kudu.service.configuration.KuduConfiguration;
+import software.tnb.kudu.validation.KuduValidation;
+
+import java.util.List;
+import java.util.Optional;
+
+public abstract class Kudu extends ConfigurableService<NoAccount, KuduClient, KuduValidation, KuduConfiguration> implements WithDockerImage {
+
+    protected static final int TSERVER_RPC_PORT = 7050;
+    protected static final int TSERVER_HTTP_PORT = 8050;
+    protected static final int MASTER_RPC_PORT = 7051;
+    protected static final int MASTER_HTTP_PORT = 8051;
+
+    protected static final String MASTER_PREFIX = "kudu-master";
+    protected static final String TSERVER_PREFIX = "kudu-tserver";
+
+    public abstract List<String> getMastersUsingHttp();
+
+    public abstract List<String> getTserversUsingHttp();
+
+    public abstract List<String> getMastersUsingRpc();
+
+    public abstract List<String> getTserversUsingRpc();
+
+    @Override
+    public String defaultImage() {
+        return "quay.io/rh_integration/apache/kudu:1.17";
+    }
+
+    @Override
+    protected void defaultConfiguration() {
+        getConfiguration().withMasterNumber(3).withTabletNumber(3);
+    }
+
+    public KuduValidation validation() {
+        return Optional.ofNullable(validation).orElseGet(() -> validation = new KuduValidation(client));
+    }
+}

--- a/system-x/services/kudu/src/main/java/software/tnb/kudu/service/configuration/KuduConfiguration.java
+++ b/system-x/services/kudu/src/main/java/software/tnb/kudu/service/configuration/KuduConfiguration.java
@@ -1,0 +1,27 @@
+package software.tnb.kudu.service.configuration;
+
+import software.tnb.common.service.configuration.ServiceConfiguration;
+
+public class KuduConfiguration extends ServiceConfiguration {
+
+    private static final String MASTER_NUM = "kudu.master.num";
+    private static final String TABLET_NUM = "kudu.tablet.num";
+
+    public KuduConfiguration withMasterNumber(Integer masterNumber) {
+        set(MASTER_NUM, masterNumber);
+        return this;
+    }
+
+    public Integer masterNumber() {
+        return get(MASTER_NUM, Integer.class);
+    }
+
+    public KuduConfiguration withTabletNumber(Integer tabletNumber) {
+        set(TABLET_NUM, tabletNumber);
+        return this;
+    }
+
+    public Integer tabletNumber() {
+        return get(TABLET_NUM, Integer.class);
+    }
+}

--- a/system-x/services/kudu/src/main/java/software/tnb/kudu/validation/KuduValidation.java
+++ b/system-x/services/kudu/src/main/java/software/tnb/kudu/validation/KuduValidation.java
@@ -1,0 +1,57 @@
+package software.tnb.kudu.validation;
+
+import software.tnb.common.validation.Validation;
+import software.tnb.kudu.resource.client.KuduClient;
+
+import java.util.List;
+import java.util.Map;
+
+public class KuduValidation implements Validation {
+
+    private final KuduClient client;
+
+    public KuduValidation(KuduClient client) {
+        this.client = client;
+    }
+
+    public String getLeaderMaster() {
+        return client.findLeaderMasterServer();
+    }
+
+    public boolean tableExists(String tableName) {
+        return client.tableExists(tableName);
+    }
+
+    /**
+     * example of definition
+     * <span>
+     *  { "table_name": "test", "schema": { "columns": [ { "column_name": "id", "column_type": "INT32", "default_value": "1" }
+     *  , { "column_name": "key", "column_type": "INT64", "is_nullable": false, "comment": "range partition column" }
+     *  , { "column_name": "name", "column_type": "STRING", "is_nullable": false, "comment": "user name" } ]
+     *  , "key_column_names": ["id", "key"] }, "partition": { "hash_partitions": [{"columns": ["id"], "num_buckets": 2, "seed": 8}]
+     *  , "range_partition": { "columns": ["key"], "range_bounds": [ { "lower_bound": {"bound_type": "inclusive", "bound_values": ["2"]}
+     *  , "upper_bound": {"bound_type": "exclusive", "bound_values": ["3"]} }
+     *  , { "lower_bound": {"bound_type": "inclusive", "bound_values": ["3"]} } ] } }
+     *  , "extra_configs": { "configs": { "kudu.table.history_max_age_sec": "3600" } }, "comment": "a test table", "num_replicas": 3 }
+     * </span>
+     *
+     * @param tableDefinition {@link Map}
+     */
+    public void createTable(Map<String, Object> tableDefinition) {
+        assert tableDefinition != null;
+        assert tableDefinition.get("table_name") != null;
+        assert tableDefinition.get("schema") != null;
+        client.createTable(tableDefinition);
+    }
+
+    /**
+     * Return the rows of a table
+     * @param tableName
+     * @param columns Optional
+     * @param predicates Optional
+     * @return List of String, the scanned rows in a raw format
+     */
+    public List<String> listRows(String tableName, List<String> columns, String predicates) {
+        return client.listRows(tableName, columns, predicates);
+    }
+}

--- a/system-x/services/pom.xml
+++ b/system-x/services/pom.xml
@@ -29,6 +29,7 @@
         <module>jira</module>
         <module>http</module>
         <module>kafka</module>
+        <module>kudu</module>
         <module>infinispan</module>
         <module>db</module>
         <module>mail</module>


### PR DESCRIPTION
Adds Kudu cluster automation for OpenShift, in my opinion it doesn't make sense to deploy it locally, since the cluster needs to be in the same network of the application/client, the testcontainers should be in host network, with at least 6 random port (the cluster needs 6 nodes). So that, at the moment, the implementation supports only OpenShift.