### PR TITLE
Remove dcId, dcIP from telegram

### DIFF
--- a/system-x/services/telegram/src/main/java/software/tnb/telegram/account/TelegramAccount.java
+++ b/system-x/services/telegram/src/main/java/software/tnb/telegram/account/TelegramAccount.java
@@ -6,8 +6,6 @@ import software.tnb.common.account.WithId;
 public class TelegramAccount implements Account, WithId {
     private String app_hash;
     private String appId;
-    private String dcId;
-    private String dcIp;
     private String sessionString;
     private String token;
     private String username;
@@ -23,14 +21,6 @@ public class TelegramAccount implements Account, WithId {
 
     public String getAppId() {
         return appId;
-    }
-
-    public String getDcId() {
-        return dcId;
-    }
-
-    public String getDcIp() {
-        return dcIp;
     }
 
     public String getSessionString() {

--- a/system-x/services/telegram/src/main/java/software/tnb/telegram/resource/openshift/OpenshiftTelegramBotAPI.java
+++ b/system-x/services/telegram/src/main/java/software/tnb/telegram/resource/openshift/OpenshiftTelegramBotAPI.java
@@ -56,7 +56,6 @@ public class OpenshiftTelegramBotAPI extends TelegramBotApi implements Openshift
         WaitUtils.waitFor(() -> servicePod() == null, "Waiting until the pod is removed");
         LOG.debug("Deleting image stream");
         OpenshiftClient.get().imageStreams().withLabel(OpenshiftConfiguration.openshiftDeploymentLabel(), name()).delete();
-
     }
 
     @Override

--- a/system-x/services/telegram/src/main/java/software/tnb/telegram/service/Telegram.java
+++ b/system-x/services/telegram/src/main/java/software/tnb/telegram/service/Telegram.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public abstract class Telegram extends Service<TelegramAccount, NoClient, TelegramValidation> implements WithDockerImage {
     @Override
     public String defaultImage() {
-        return "quay.io/fuse_qe/telegram-client:latest";
+        return "quay.io/fuse_qe/telegram-client-without-dc:latest";
     }
 
     public abstract String execInContainer(String... commands);
@@ -26,8 +26,6 @@ public abstract class Telegram extends Service<TelegramAccount, NoClient, Telegr
 
     public Map<String, String> getEnv() {
         Map<String, String> env = new HashMap<>();
-        env.put("TELEGRAM_DC_ID", account().getDcId());
-        env.put("TELEGRAM_DC_IP", account().getDcIp());
         env.put("TELEGRAM_API_ID", account().getAppId());
         env.put("TELEGRAM_API_HASH", account().getAppHash());
         env.put("TELEGRAM_SESSION", account().getSessionString());

--- a/system-x/services/telegram/src/main/resources/docker/get_messages.py
+++ b/system-x/services/telegram/src/main/resources/docker/get_messages.py
@@ -6,9 +6,8 @@ from telethon.sessions import StringSession
 def transform(message):
     return {'sender_id': message.sender_id, 'text': message.text, 'chat_id': message.chat.id}
 
-def get_msgs(dc_id, dc_ip, api_id, api_hash, session_str, username):
+def get_msgs(api_id, api_hash, session_str, username):
     client = TelegramClient(StringSession(session_str), api_id, api_hash)
-    client.session.set_dc(dc_id, dc_ip, 80)
     limit = 1
     if (len(sys.argv) == 2):
         limit = int(sys.argv[1])
@@ -16,11 +15,9 @@ def get_msgs(dc_id, dc_ip, api_id, api_hash, session_str, username):
         print(json.dumps(list(map(transform, client.get_messages(username, limit)))))
 
 if __name__ == '__main__':
-    arg_dc_id = int(os.environ["TELEGRAM_DC_ID"])
-    arg_dc_ip = os.environ["TELEGRAM_DC_IP"]
     arg_api_id = int(os.environ["TELEGRAM_API_ID"])
     arg_api_hash = os.environ["TELEGRAM_API_HASH"]
     arg_session_str = os.environ["TELEGRAM_SESSION"]
     arg_username = os.environ["TELEGRAM_USERNAME"]
 
-    get_msgs(arg_dc_id, arg_dc_ip, arg_api_id, arg_api_hash, arg_session_str, arg_username)
+    get_msgs(arg_api_id, arg_api_hash, arg_session_str, arg_username)

--- a/system-x/services/telegram/src/main/resources/docker/login.py
+++ b/system-x/services/telegram/src/main/resources/docker/login.py
@@ -3,16 +3,13 @@ import os
 from telethon.sync import TelegramClient
 from telethon.sessions import StringSession
 
-def login(dc_id, dc_ip, api_id, api_hash):
+def login(api_id, api_hash):
     client = TelegramClient(StringSession(), api_id, api_hash)
-    client.session.set_dc(dc_id, dc_ip, 80)
     with client:
         print("Your session string is:", client.session.save())
 
 if __name__ == '__main__':
-    arg_dc_id = int(os.environ["TELEGRAM_DC_ID"])
-    arg_dc_ip = os.environ["TELEGRAM_DC_IP"]
     arg_api_id = int(os.environ["TELEGRAM_API_ID"])
     arg_api_hash = os.environ["TELEGRAM_API_HASH"]
 
-    login(arg_dc_id, arg_dc_ip, arg_api_id, arg_api_hash)
+    login(arg_api_id, arg_api_hash)

--- a/system-x/services/telegram/src/main/resources/docker/send_message.py
+++ b/system-x/services/telegram/src/main/resources/docker/send_message.py
@@ -3,16 +3,13 @@ import os, sys, asyncio
 from telethon.sync import TelegramClient
 from telethon.sessions import StringSession
 
-async def send(dc_id, dc_ip, api_id, api_hash, session_str, username, text):
+async def send(api_id, api_hash, session_str, username, text):
     client = TelegramClient(StringSession(session_str), api_id, api_hash)
-    client.session.set_dc(dc_id, dc_ip, 80)
     async with client:
         msgObject = await client.send_message(username, text)
         print(f'Message Sent: "{msgObject.message}"')
 
 if __name__ == '__main__':
-    arg_dc_id = int(os.environ["TELEGRAM_DC_ID"])
-    arg_dc_ip = os.environ["TELEGRAM_DC_IP"]
     arg_api_id = int(os.environ["TELEGRAM_API_ID"])
     arg_api_hash = os.environ["TELEGRAM_API_HASH"]
     arg_session_str = os.environ["TELEGRAM_SESSION"]
@@ -21,4 +18,4 @@ if __name__ == '__main__':
     if (len(sys.argv) == 2):
         arg_text = sys.argv[1]
 
-    asyncio.run(send(arg_dc_id, arg_dc_ip, arg_api_id, arg_api_hash, arg_session_str, arg_username, arg_text))
+    asyncio.run(send(arg_api_id, arg_api_hash, arg_session_str, arg_username, arg_text))


### PR DESCRIPTION
It seems dc ip, id (pointing to test server) and test token (bot/client)  can't be used as previously:
- I am afraid it isn't possible to generate test account/bot as earlier, step https://github.com/openshift-integration/kamelet-catalog/tree/main/test/telegram#create-an-accountbot-in-the-telegram-test-space doesn't work - even if provided real number, verification code is never delivered.
- I tried to create new test bot via Test server https://docs.ton.org/develop/dapps/telegram-apps/testing-apps , but it turns out all 3 public test accounts are blocked (test phone numbers https://core.telegram.org/api/auth#test-accounts (btw these can't be used in preceding step))
- It seems it isn't possible to connect to test servers without test token (step client.session.set_dc(dc_id, dc_ip, 80) needs to be skipped in [login.py](https://github.com/tnb-software/TNB/blob/main/system-x/services/telegram/src/main/resources/docker/login.py#L8) , also in send_message and get_messages)
