### PR TITLE
[JKube] Add nodeAffinity option to JKube deployment config

### DIFF
--- a/fuse-products/src/main/java/software/tnb/product/deploystrategy/impl/custom/CustomJKubeStrategy.java
+++ b/fuse-products/src/main/java/software/tnb/product/deploystrategy/impl/custom/CustomJKubeStrategy.java
@@ -155,12 +155,20 @@ public class CustomJKubeStrategy extends OpenshiftCustomDeployer {
 
     protected void createCustomDeployment(Path jkubeFolder) {
         try {
-            final String deploymentContent = StringUtils.replace(IOUtils.resourceToString("/openshift/csb/deployment.yaml", StandardCharsets.UTF_8),
-                "XX_JAVA_OPTS_APPEND", getPropertiesForJVM(integrationBuilder).replaceAll("\"", "\\\\\""));
+            final String deploymentContent = getDeploymentContent();
             software.tnb.common.utils.IOUtils.writeFile(jkubeFolder.resolve("deployment.yaml"), deploymentContent);
         } catch (IOException e) {
             throw new RuntimeException("Error creating custom deployment.yaml", e);
         }
+    }
+
+    private String getDeploymentContent() throws IOException {
+        String deploymentContent = IOUtils.resourceToString("/openshift/csb/deployment.yaml", StandardCharsets.UTF_8);
+        deploymentContent = StringUtils.replace(deploymentContent, "XX_JAVA_OPTS_APPEND",
+                getPropertiesForJVM(integrationBuilder).replaceAll("\"", "\\\\\""));
+        deploymentContent = StringUtils.replace(deploymentContent, "XX_NODE_HOSTNAME",
+                System.getProperty("node.hostname", ""));
+        return deploymentContent;
     }
 
     private void createConfigMap(Path jkubeFolder, final File pomFile) {

--- a/fuse-products/src/main/resources/openshift/csb/deployment.yaml
+++ b/fuse-products/src/main/resources/openshift/csb/deployment.yaml
@@ -5,6 +5,16 @@ spec:
   replicas: 1
   template:
     spec:
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: kubernetes.io/hostname
+                    operator: In
+                    values:
+                      - "XX_NODE_HOSTNAME"
       volumes:
         - name: config
           configMap:


### PR DESCRIPTION
Add a nodeAffinity option to JKube's `deployment.yaml` configuration.

When the option `-Dnode.hostname=<hostname>` is specified, the scheduler attempts to find a node with a hostname that matches the provided string. If the string does not match any node or if the option is not specified, the scheduler will select any available node as it did previously.