### PR TITLE
🚑 JKube empty env workaround

### DIFF
--- a/fuse-products/src/main/java/software/tnb/product/deploystrategy/impl/JKubeWithExternalRepoStrategy.java
+++ b/fuse-products/src/main/java/software/tnb/product/deploystrategy/impl/JKubeWithExternalRepoStrategy.java
@@ -97,6 +97,8 @@ public class JKubeWithExternalRepoStrategy extends CustomJKubeStrategy {
                 FileUtils.copyInputStreamToFile(getClass().getResourceAsStream("/openshift/csb/jkube-config.xml"), addConfigFile);
                 IOUtils.replaceInFile(addConfigFile.toPath(), Map.of("XX_JAVA_OPTS_APPEND", getPropertiesForJVM(integrationBuilder)
                     .replaceAll("\"", "\\\\\"")));
+                //remove empty env to avoid https://github.com/eclipse-jkube/jkube/issues/3220
+                IOUtils.replaceInFile(addConfigFile.toPath(), Map.of("<JAVA_OPTS_APPEND></JAVA_OPTS_APPEND>", ""));
             } catch (IOException e) {
                 throw new RuntimeException("unable to create temp file for env-config", e);
             }


### PR DESCRIPTION
due to https://github.com/eclipse-jkube/jkube/issues/3220, the pre-configured jkube xml configuration will be cleaned up by the empty env variables