### PR TITLE
Make Flink server configurable

### DIFF
--- a/system-x/services/flink/src/main/java/software/tnb/flink/resource/local/LocalFlink.java
+++ b/system-x/services/flink/src/main/java/software/tnb/flink/resource/local/LocalFlink.java
@@ -55,4 +55,9 @@ public class LocalFlink extends Flink implements Deployable {
     @Override
     public void closeResources() {
     }
+
+    @Override
+    protected void defaultConfiguration() {
+
+    }
 }

--- a/system-x/services/flink/src/main/java/software/tnb/flink/resource/openshift/OpenshiftFlink.java
+++ b/system-x/services/flink/src/main/java/software/tnb/flink/resource/openshift/OpenshiftFlink.java
@@ -1,109 +1,67 @@
 package software.tnb.flink.resource.openshift;
 
 import software.tnb.common.deployment.OpenshiftDeployable;
-import software.tnb.common.deployment.WithCustomResource;
-import software.tnb.common.deployment.WithExternalHostname;
 import software.tnb.common.deployment.WithName;
-import software.tnb.common.deployment.WithOperatorHub;
-import software.tnb.common.openshift.OpenshiftClient;
-import software.tnb.common.utils.HTTPUtils;
-import software.tnb.common.utils.WaitUtils;
 import software.tnb.flink.service.Flink;
+import software.tnb.flink.service.configuration.FlinkConfiguration;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.auto.service.AutoService;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.function.Predicate;
 
-import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
-import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
-import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodList;
-import io.fabric8.kubernetes.client.readiness.Readiness;
-import io.fabric8.openshift.api.model.Route;
-import io.fabric8.openshift.api.model.RouteBuilder;
 
 @AutoService(Flink.class)
-public class OpenshiftFlink extends Flink implements OpenshiftDeployable, WithExternalHostname, WithOperatorHub, WithCustomResource,
-    WithName {
+public class OpenshiftFlink extends Flink implements OpenshiftDeployable, WithName {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenshiftFlink.class);
+    private OpenshiftDeployable delegate;
 
-    private Route apiRoute;
-
-    @Override
-    public String operatorChannel() {
-        return "alpha";
+    public OpenshiftDeployable selectOpenshiftFlinkService() {
+        OpenshiftDeployable deployable = new OpenshiftFlinkOperator();
+        if (getCurrentForcingConfiguration()) {
+            deployable = new OpenshiftFlinkImage();
+            ((FlinkConfiguration) ((OpenshiftFlinkImage) deployable).getConfiguration()).forceUseImageServer(true);
+        } else {
+            ((FlinkConfiguration) ((OpenshiftFlink) deployable).getConfiguration()).forceUseImageServer(false);
+        }
+        return deployable;
     }
 
     @Override
-    public String operatorName() {
-        return "flink-kubernetes-operator";
-    }
-
-    @Override
-    public String operatorCatalog() {
-        return "community-operators";
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+        this.delegate = selectOpenshiftFlinkService();
+        OpenshiftDeployable.super.beforeAll(extensionContext);
     }
 
     @Override
     public void undeploy() {
-        LOG.info("Undeploying Flink resources");
-        OpenshiftClient.get().genericKubernetesResources(apiVersion(), kind()).delete();
-        WaitUtils.waitFor(() -> servicePod() == null, "Waiting until the pod is removed");
+        this.delegate.undeploy();
     }
 
     @Override
     public void openResources() {
-        apiRoute = OpenshiftClient.get().routes().createOrReplace(new RouteBuilder()
-            .editOrNewMetadata()
-            .withName(name())
-            .endMetadata()
-            .editOrNewSpec()
-            .withNewTo().withKind("Service").withName(host()).withWeight(100)
-            .endTo()
-            .withNewPort().withTargetPort(new IntOrString("rest")).endPort()
-            .endSpec()
-            .build());
-
-        WaitUtils.waitFor(() -> HTTPUtils.getInstance().get(externalHostname(), false).isSuccessful()
-            , 5, 5000L
-            , "Waiting until the Flink API route is ready");
+        this.delegate.openResources();
     }
 
     @Override
     public void closeResources() {
-        if (apiRoute != null) {
-            OpenshiftClient.get().routes().resource(apiRoute).delete();
-        }
+        this.delegate.closeResources();
     }
 
     @Override
     public void create() {
-        LOG.debug("Creating Flink subscription");
-
-        // Create subscription if needed
-        createSubscription();
-
-        WaitUtils.waitFor(() -> {
-            final PodList pods = OpenshiftClient.get().pods().withLabel("app.kubernetes.io/name", "flink-kubernetes-operator").list();
-            return pods.getItems().size() > 0 && pods.getItems().stream().allMatch(Readiness::isPodReady);
-        }, "Wait for operator PODs are ready");
-
-        OpenshiftClient.get().genericKubernetesResources(apiVersion(), kind()).resource(customResource()).create();
+        this.delegate.create();
     }
 
     @Override
     public boolean isDeployed() {
-        List<Pod> pods = OpenshiftClient.get().pods().withLabel("app.kubernetes.io/name", "flink-kubernetes-operator").list().getItems();
-        return pods.size() == 1 && pods.stream().allMatch(Readiness::isPodReady)
-            && servicePods().size() == 2;
+        return this.delegate.isDeployed();
     }
 
     @Override
@@ -113,53 +71,12 @@ public class OpenshiftFlink extends Flink implements OpenshiftDeployable, WithEx
 
     @Override
     public Predicate<Pod> podSelector() {
-        return p -> OpenshiftClient.get().hasLabels(p, Map.of("app", name()))
-            && (OpenshiftClient.get().hasLabels(p, Map.of("component", "jobmanager"))
-            || OpenshiftClient.get().hasLabels(p, Map.of("component", "taskmanager")));
-    }
-
-    @Override
-    public String kind() {
-        return "FlinkDeployment";
-    }
-
-    @Override
-    public String apiVersion() {
-        return "flink.apache.org/v1beta1";
-    }
-
-    @Override
-    public GenericKubernetesResource customResource() {
-        Map<String, Object> spec = new HashMap<>();
-        Map<String, String> flinkConfiguration = Map.of("taskmanager.numberOfTaskSlots", "2");
-        spec.put("flinkConfiguration", flinkConfiguration);
-        spec.put("flinkVersion", "v1_18");
-        spec.put("image", image());
-        spec.put("mode", "standalone");
-        spec.put("serviceAccount", "flink");
-        Map<String, Object> resource = Map.of("cpu", 1, "memory", "2048m");
-        Map<String, Object> jobManager = Map.of("replicas", 1, "resource", resource);
-        Map<String, Object> taskManager = Map.of("resource", resource);
-        spec.put("jobManager", jobManager);
-        spec.put("taskManager", taskManager);
-
-        return new GenericKubernetesResourceBuilder()
-            .withKind(kind())
-            .withApiVersion(apiVersion())
-            .withNewMetadata()
-            .withName(name())
-            .endMetadata()
-            .withAdditionalProperties(Map.of("spec", spec)).build();
-    }
-
-    @Override
-    public String externalHostname() {
-        return "http://" + apiRoute.getSpec().getHost();
+        return this.delegate.podSelector();
     }
 
     @Override
     public String host() {
-        return name() + "-rest";
+        return getCurrentForcingConfiguration() ? "jobmanager" : name() + "-rest";
     }
 
     @Override

--- a/system-x/services/flink/src/main/java/software/tnb/flink/resource/openshift/OpenshiftFlinkImage.java
+++ b/system-x/services/flink/src/main/java/software/tnb/flink/resource/openshift/OpenshiftFlinkImage.java
@@ -1,0 +1,287 @@
+package software.tnb.flink.resource.openshift;
+
+import software.tnb.common.config.OpenshiftConfiguration;
+import software.tnb.common.deployment.OpenshiftDeployable;
+import software.tnb.common.deployment.WithExternalHostname;
+import software.tnb.common.deployment.WithName;
+import software.tnb.common.openshift.OpenshiftClient;
+import software.tnb.common.utils.HTTPUtils;
+import software.tnb.common.utils.WaitUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.ServiceAccountBuilder;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteBuilder;
+
+public class OpenshiftFlinkImage extends OpenshiftFlink implements OpenshiftDeployable, WithExternalHostname, WithName {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenshiftFlinkImage.class);
+
+    private Route apiRoute;
+
+    private String sccName;
+    private String serviceAccountName;
+
+    @Override
+    public void undeploy() {
+        LOG.info("Undeploying Flink server");
+        OpenshiftClient.get().securityContextConstraints().withName(sccName).delete();
+        OpenshiftClient.get().serviceAccounts().withName(serviceAccountName).delete();
+        OpenshiftClient.get().apps().deployments().withName(host()).delete();
+        OpenshiftClient.get().apps().deployments().withName(nameTaskManager()).delete();
+        OpenshiftClient.get().services().withLabel(OpenshiftConfiguration.openshiftDeploymentLabel(), name()).delete();
+        WaitUtils.waitFor(() -> Objects.requireNonNull(filterPods(host())).isEmpty(), "Waiting until the pod is removed");
+        WaitUtils.waitFor(() -> Objects.requireNonNull(filterPods(nameTaskManager())).isEmpty(), "Waiting until the pod is removed");
+    }
+
+    @Override
+    public void openResources() {
+        apiRoute = OpenshiftClient.get().routes().createOrReplace(new RouteBuilder()
+            .editOrNewMetadata()
+               .withName(name())
+            .endMetadata()
+            .editOrNewSpec()
+               .withNewTo().withKind("Service").withName("jobmanager-rest").withWeight(100)
+               .endTo()
+               .withNewPort().withTargetPort(new IntOrString(targetPort())).endPort()
+            .endSpec()
+        .build());
+
+        WaitUtils.waitFor(() -> HTTPUtils.getInstance().get(externalHostname(), false).isSuccessful()
+            , 5, 5000L
+            , "Waiting until the Flink API route is ready");
+    }
+
+    @Override
+    public void closeResources() {
+        if (apiRoute != null) {
+            OpenshiftClient.get().routes().resource(apiRoute).delete();
+        }
+    }
+
+    @Override
+    public void create() {
+        sccName = "tnb-flink-" + OpenshiftClient.get().getNamespace();
+
+        serviceAccountName = name() + "-sa";
+
+        OpenshiftClient.get().serviceAccounts()
+            .createOrReplace(new ServiceAccountBuilder()
+                .withNewMetadata()
+                  .withName(serviceAccountName)
+                .endMetadata()
+            .build()
+        );
+
+        OpenshiftClient.get().addUsersToSecurityContext(
+            OpenshiftClient.get().createSecurityContext(sccName, "anyuid", "SYS_CHROOT"),
+            OpenshiftClient.get().getServiceAccountRef(serviceAccountName));
+
+        LOG.info("Deploying Flink server");
+
+        createDeployments(host(), "jobmanager");
+
+        createJobManagerService();
+
+        createRestService();
+
+        WaitUtils.waitFor(() -> {
+            return filterPods(host()) != null && this.isReady(host());
+        }, "Waiting for pod ready");
+
+        createDeployments(nameTaskManager(), "taskmanager");
+
+        createTMQueryStateService();
+
+        WaitUtils.waitFor(() -> {
+            return filterPods(nameTaskManager()) != null && this.isDeployed();
+        }, "Waiting for pod ready");
+
+    }
+
+    private void createDeployments(String containerName, String command) {
+        OpenshiftClient.get().apps().deployments().createOrReplace(
+            new DeploymentBuilder()
+                .withNewMetadata()
+                    .withName(containerName)
+                    .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), name())
+                    .addToLabels("component", containerName)
+                    .addToAnnotations("openshift.io/scc", sccName)
+                .endMetadata()
+                .editOrNewSpec()
+                .editOrNewSelector()
+                    .addToMatchLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), name())
+                    .addToMatchLabels("component", containerName)
+                .endSelector()
+                .withReplicas(1)
+                .editOrNewTemplate()
+                    .editOrNewMetadata()
+                        .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), name())
+                        .addToLabels("component", containerName)
+                    .endMetadata()
+                    .editOrNewSpec()
+                        .withServiceAccount(serviceAccountName)
+                        .addNewContainer()
+                            .withName(containerName)
+                            .withImage(image())
+                            .addAllToEnv(containerEnvironment().entrySet().stream().map(e -> new EnvVar(e.getKey(), e.getValue(), null))
+                                .collect(Collectors.toList()))
+                            .withCommand("/docker-entrypoint.sh")
+                            .withArgs(command)
+                            .addNewPort()
+                                .withContainerPort(6123)
+                                .withName("rpc")
+                            .endPort()
+                            .addNewPort()
+                                .withContainerPort(6124)
+                                .withName("blob-server")
+                            .endPort()
+                            .addNewPort()
+                                .withContainerPort(8081)
+                                .withName("webui")
+                            .endPort()
+                            .editOrNewSecurityContext()
+                                .editOrNewCapabilities()
+                                    .addToAdd("SYS_CHROOT")
+                                .endCapabilities()
+                            .endSecurityContext()
+                        .endContainer()
+                    .endSpec()
+                .endTemplate()
+            .endSpec()
+        .build());
+    }
+
+    private void createRestService() {
+        OpenshiftClient.get().services().createOrReplace(new ServiceBuilder()
+            .editOrNewMetadata()
+                .withName("jobmanager-rest")
+                .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), name())
+            .endMetadata()
+            .editOrNewSpec()
+                .withType("NodePort")
+                .addNewPort()
+                    .withName("rest")
+                    .withPort(8081)
+                    .withTargetPort(new IntOrString(8081))
+                    .withNodePort(30081)
+                    .endPort()
+                .addToSelector(OpenshiftConfiguration.openshiftDeploymentLabel(), name())
+                .addToSelector("component", "jobmanager")
+            .endSpec()
+        .build());
+    }
+
+    private void createJobManagerService() {
+        OpenshiftClient.get().services().createOrReplace(new ServiceBuilder()
+            .editOrNewMetadata()
+                .withName("jobmanager")
+                .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), name())
+            .endMetadata()
+            .editOrNewSpec()
+                .withType("ClusterIP")
+                .addNewPort()
+                    .withName("rpc")
+                    .withPort(6123)
+                .endPort()
+                .addNewPort()
+                    .withName("blob-server")
+                    .withPort(6124)
+                .endPort()
+                .addNewPort()
+                    .withName("webui")
+                    .withPort(8081)
+                .endPort()
+                .addToSelector(OpenshiftConfiguration.openshiftDeploymentLabel(), name())
+                .addToSelector("component", host())
+            .endSpec()
+        .build());
+    }
+
+    private void createTMQueryStateService() {
+        OpenshiftClient.get().services().createOrReplace(new ServiceBuilder()
+            .editOrNewMetadata()
+                .withName("taskmanager-query-state")
+                .addToLabels(OpenshiftConfiguration.openshiftDeploymentLabel(), name())
+            .endMetadata()
+            .editOrNewSpec()
+                .withType("NodePort")
+                .addNewPort()
+                    .withName("query-state")
+                    .withPort(6125)
+                    .withTargetPort(new IntOrString(6125))
+                    .withNodePort(30025)
+                .endPort()
+                .addToSelector(OpenshiftConfiguration.openshiftDeploymentLabel(), name())
+                .addToSelector("component", nameTaskManager())
+            .endSpec()
+        .build());
+    }
+
+    @Override
+    public boolean isDeployed() {
+        return !OpenshiftClient.get().apps().deployments().withLabel(OpenshiftConfiguration.openshiftDeploymentLabel(), name()).list()
+            .getItems().isEmpty();
+    }
+
+    public String nameTaskManager() {
+        return "taskmanager";
+    }
+
+    @Override
+    public Predicate<Pod> podSelector() {
+        return podSelector(nameTaskManager());
+    }
+
+    @Override
+    public String externalHostname() {
+        return "http://" + apiRoute.getSpec().getHost();
+    }
+
+    public int targetPort() {
+        return port();
+    }
+
+    private Map<String, String> containerEnvironment() {
+        return Map.of(
+            "FLINK_PROPERTIES", "jobmanager.rpc.address: jobmanager"
+        );
+    }
+
+    private List<PodResource> filterPods(String pod) {
+        try {
+            return OpenshiftClient.get().pods().list().getItems().stream()
+                .filter(podSelector(pod))
+                .map(p -> OpenshiftClient.get().pods().withName(p.getMetadata().getName()))
+                .collect(Collectors.toList());
+        } catch (KubernetesClientException kce) {
+            // Just in case of some transient error
+            return null;
+        }
+    }
+
+    private Predicate<Pod> podSelector(String selector) {
+        return p -> OpenshiftClient.get().hasLabels(p, Map.of("component", selector));
+    }
+
+    private boolean isReady(String pod) {
+        final List<PodResource> servicePods = filterPods(pod);
+        return servicePods != null && !servicePods.isEmpty() && servicePods.stream().allMatch(Resource::isReady);
+    }
+}

--- a/system-x/services/flink/src/main/java/software/tnb/flink/resource/openshift/OpenshiftFlinkOperator.java
+++ b/system-x/services/flink/src/main/java/software/tnb/flink/resource/openshift/OpenshiftFlinkOperator.java
@@ -1,0 +1,151 @@
+package software.tnb.flink.resource.openshift;
+
+import software.tnb.common.deployment.OpenshiftDeployable;
+import software.tnb.common.deployment.WithCustomResource;
+import software.tnb.common.deployment.WithExternalHostname;
+import software.tnb.common.deployment.WithName;
+import software.tnb.common.deployment.WithOperatorHub;
+import software.tnb.common.openshift.OpenshiftClient;
+import software.tnb.common.utils.HTTPUtils;
+import software.tnb.common.utils.WaitUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.readiness.Readiness;
+import io.fabric8.openshift.api.model.Route;
+import io.fabric8.openshift.api.model.RouteBuilder;
+
+public class OpenshiftFlinkOperator extends OpenshiftFlink implements OpenshiftDeployable, WithExternalHostname, WithOperatorHub, WithCustomResource,
+    WithName {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenshiftFlink.class);
+
+    private Route apiRoute;
+
+    @Override
+    public String operatorChannel() {
+        return "alpha";
+    }
+
+    @Override
+    public String operatorName() {
+        return "flink-kubernetes-operator";
+    }
+
+    @Override
+    public String operatorCatalog() {
+        return "community-operators";
+    }
+
+    @Override
+    public void undeploy() {
+        LOG.info("Undeploying Flink resources");
+        OpenshiftClient.get().genericKubernetesResources(apiVersion(), kind()).delete();
+        WaitUtils.waitFor(() -> servicePod() == null, "Waiting until the pod is removed");
+    }
+
+    @Override
+    public void openResources() {
+        apiRoute = OpenshiftClient.get().routes().createOrReplace(new RouteBuilder()
+            .editOrNewMetadata()
+            .withName(name())
+            .endMetadata()
+            .editOrNewSpec()
+            .withNewTo().withKind("Service").withName(host()).withWeight(100)
+            .endTo()
+            .withNewPort().withTargetPort(new IntOrString("rest")).endPort()
+            .endSpec()
+            .build());
+
+        WaitUtils.waitFor(() -> HTTPUtils.getInstance().get(externalHostname(), false).isSuccessful()
+            , 5, 5000L
+            , "Waiting until the Flink API route is ready");
+    }
+
+    @Override
+    public void closeResources() {
+        if (apiRoute != null) {
+            OpenshiftClient.get().routes().resource(apiRoute).delete();
+        }
+    }
+
+    @Override
+    public void create() {
+        LOG.debug("Creating Flink subscription");
+
+        // Create subscription if needed
+        createSubscription();
+
+        WaitUtils.waitFor(() -> {
+            final PodList pods = OpenshiftClient.get().pods().withLabel("app.kubernetes.io/name", "flink-kubernetes-operator").list();
+            return pods.getItems().size() > 0 && pods.getItems().stream().allMatch(Readiness::isPodReady);
+        }, "Wait for operator PODs are ready");
+
+        OpenshiftClient.get().genericKubernetesResources(apiVersion(), kind()).resource(customResource()).create();
+    }
+
+    @Override
+    public boolean isDeployed() {
+        List<Pod> pods = OpenshiftClient.get().pods().withLabel("app.kubernetes.io/name", "flink-kubernetes-operator").list().getItems();
+        return pods.size() == 1 && pods.stream().allMatch(Readiness::isPodReady)
+            && servicePods().size() == 2;
+    }
+
+    @Override
+    public Predicate<Pod> podSelector() {
+        return p -> OpenshiftClient.get().hasLabels(p, Map.of("app", name()))
+            && (OpenshiftClient.get().hasLabels(p, Map.of("component", "jobmanager"))
+            || OpenshiftClient.get().hasLabels(p, Map.of("component", "taskmanager")));
+    }
+
+    @Override
+    public String kind() {
+        return "FlinkDeployment";
+    }
+
+    @Override
+    public String apiVersion() {
+        return "flink.apache.org/v1beta1";
+    }
+
+    @Override
+    public GenericKubernetesResource customResource() {
+        Map<String, Object> spec = new HashMap<>();
+        Map<String, String> flinkConfiguration = Map.of("taskmanager.numberOfTaskSlots", "2");
+        spec.put("flinkConfiguration", flinkConfiguration);
+        spec.put("flinkVersion", "v1_18");
+        spec.put("image", image());
+        spec.put("mode", "standalone");
+        spec.put("serviceAccount", "flink");
+        Map<String, Object> resource = Map.of("cpu", 1, "memory", "2048m");
+        Map<String, Object> jobManager = Map.of("replicas", 1, "resource", resource);
+        Map<String, Object> taskManager = Map.of("resource", resource);
+        spec.put("jobManager", jobManager);
+        spec.put("taskManager", taskManager);
+
+        return new GenericKubernetesResourceBuilder()
+            .withKind(kind())
+            .withApiVersion(apiVersion())
+            .withNewMetadata()
+            .withName(name())
+            .endMetadata()
+            .withAdditionalProperties(Map.of("spec", spec)).build();
+    }
+
+    @Override
+    public String externalHostname() {
+        return "http://" + apiRoute.getSpec().getHost();
+    }
+
+}

--- a/system-x/services/flink/src/main/java/software/tnb/flink/service/Flink.java
+++ b/system-x/services/flink/src/main/java/software/tnb/flink/service/Flink.java
@@ -3,10 +3,12 @@ package software.tnb.flink.service;
 import software.tnb.common.account.NoAccount;
 import software.tnb.common.client.NoClient;
 import software.tnb.common.deployment.WithDockerImage;
-import software.tnb.common.service.Service;
+import software.tnb.common.service.ConfigurableService;
 import software.tnb.common.validation.NoValidation;
+import software.tnb.flink.service.configuration.FlinkConfiguration;
 
-public abstract class Flink extends Service<NoAccount, NoClient, NoValidation> implements WithDockerImage {
+public abstract class Flink<A extends NoAccount, C extends NoClient, V extends NoValidation>
+    extends ConfigurableService<A, C, V, FlinkConfiguration> implements WithDockerImage {
 
     protected static final int PORT = 8081;
 
@@ -14,8 +16,17 @@ public abstract class Flink extends Service<NoAccount, NoClient, NoValidation> i
 
     public abstract int port();
 
-    @Override
     public String defaultImage() {
         return "quay.io/fuse_qe/flink:java17";
     }
+
+    @Override
+    protected void defaultConfiguration() {
+        getConfiguration().forceUseImageServer(false);
+    }
+
+    protected boolean getCurrentForcingConfiguration() {
+        return getConfiguration().isImageServerForced();
+    }
+
 }

--- a/system-x/services/flink/src/main/java/software/tnb/flink/service/configuration/FlinkConfiguration.java
+++ b/system-x/services/flink/src/main/java/software/tnb/flink/service/configuration/FlinkConfiguration.java
@@ -1,0 +1,18 @@
+package software.tnb.flink.service.configuration;
+
+import software.tnb.common.service.configuration.ServiceConfiguration;
+
+public class FlinkConfiguration extends ServiceConfiguration {
+
+    private static final String FORCE_USE_IMAGE_SERVER = "flink.use.image.server";
+
+    public FlinkConfiguration forceUseImageServer(boolean value) {
+        set(FORCE_USE_IMAGE_SERVER, value);
+        return this;
+    }
+
+    public boolean isImageServerForced() {
+        return get(FORCE_USE_IMAGE_SERVER, Boolean.class);
+    }
+}
+


### PR DESCRIPTION
Due to Flink Operator unaivalability over IBM OCP clusters (P/Z) we need to make Flink system-x configurable (choice between Operator/Image for server deploying)