### PR TITLE
[jaeger] Fix Local configuration

### DIFF
--- a/system-x/services/jaeger/src/main/java/software/tnb/jaeger/resource/local/LocalJaeger.java
+++ b/system-x/services/jaeger/src/main/java/software/tnb/jaeger/resource/local/LocalJaeger.java
@@ -71,7 +71,7 @@ public class LocalJaeger extends Jaeger implements Deployable, WithDockerImage {
 
     @NotNull
     private String getUrl(JaegerConfiguration.WithPort port) {
-        return String.format("http://%s:%d", container.getHost(), port.portNumber());
+        return String.format("http://%s:%d", container == null ? "localhost" : container.getHost(), port.portNumber());
     }
 
     @Override


### PR DESCRIPTION
since `getUrl` method can be called during the configuration, so before the deployment, the `container` variable can be null