### PR TITLE
[opentelemetry] Fix local error in case of external configuration

### DIFF
--- a/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/resource/local/LocalOpenTelemetryCollector.java
+++ b/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/resource/local/LocalOpenTelemetryCollector.java
@@ -9,6 +9,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.auto.service.AutoService;
 
+import java.util.Optional;
+
 @AutoService(OpenTelemetryCollector.class)
 public class LocalOpenTelemetryCollector extends OpenTelemetryCollector implements Deployable, WithDockerImage {
     private static final Logger LOG = LoggerFactory.getLogger(LocalOpenTelemetryCollector.class);
@@ -45,12 +47,12 @@ public class LocalOpenTelemetryCollector extends OpenTelemetryCollector implemen
 
     @Override
     public String getGrpcEndpoint() {
-        return "http://localhost:" + container.getMappedPort(4317);
+        return "http://localhost:" + Optional.ofNullable(container).map(c -> c.getMappedPort(4317)).orElse(4317);
     }
 
     @Override
     public String getHttpEndpoint() {
-        return "http://localhost:" + container.getMappedPort(4318);
+        return "http://localhost:" + Optional.ofNullable(container).map(c -> c.getMappedPort(4318)).orElse(4318);
     }
 
     @Override


### PR DESCRIPTION
in case the local instance are initialized from another `@RegisterExtension`, such as Instrumentation, it throws error