### PR TITLE
Add Hashicorp Vault Local system-x

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -256,6 +256,11 @@
             </dependency>
             <dependency>
                 <groupId>software.tnb</groupId>
+                <artifactId>system-x-hashicorp-vault</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>software.tnb</groupId>
                 <artifactId>system-x-horreum</artifactId>
                 <version>1.0-SNAPSHOT</version>
             </dependency>

--- a/system-x/services/all/pom.xml
+++ b/system-x/services/all/pom.xml
@@ -179,6 +179,10 @@
         </dependency>
         <dependency>
             <groupId>software.tnb</groupId>
+            <artifactId>system-x-hashicorp-vault</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.tnb</groupId>
             <artifactId>system-x-horreum</artifactId>
         </dependency>
         <dependency>

--- a/system-x/services/hashicorp-vault/pom.xml
+++ b/system-x/services/hashicorp-vault/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>system-x-services</artifactId>
+        <groupId>software.tnb</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>system-x-hashicorp-vault</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>TNB :: System-X :: Services :: Hashicorp Vault</name>
+
+    <properties>
+        <spring-vault-core-version>3.1.2</spring-vault-core-version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.vault</groupId>
+            <artifactId>spring-vault-core</artifactId>
+            <version>${spring-vault-core-version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/system-x/services/hashicorp-vault/src/main/java/software/tnb/hashicorp/vault/account/HashicorpVaultAccount.java
+++ b/system-x/services/hashicorp-vault/src/main/java/software/tnb/hashicorp/vault/account/HashicorpVaultAccount.java
@@ -1,0 +1,11 @@
+package software.tnb.hashicorp.vault.account;
+
+import software.tnb.common.account.Account;
+
+public record HashicorpVaultAccount(String token) implements Account {
+    private static final String DEFAULT_TOKEN = "myTestToken";
+
+    public HashicorpVaultAccount() {
+        this(DEFAULT_TOKEN);
+    }
+}

--- a/system-x/services/hashicorp-vault/src/main/java/software/tnb/hashicorp/vault/resource/local/HashicorpVaultContainer.java
+++ b/system-x/services/hashicorp-vault/src/main/java/software/tnb/hashicorp/vault/resource/local/HashicorpVaultContainer.java
@@ -1,0 +1,17 @@
+package software.tnb.hashicorp.vault.resource.local;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.util.Map;
+
+public class HashicorpVaultContainer extends GenericContainer<HashicorpVaultContainer> {
+
+    public HashicorpVaultContainer(String image, Map<String, String> env, int port) {
+        super(image);
+        this.withEnv(env);
+        this.waitingFor(Wait.forListeningPort());
+        this.waitingFor(Wait.forLogMessage(".*Development.*mode.*should.*", 1));
+        this.withExposedPorts(port);
+    }
+}

--- a/system-x/services/hashicorp-vault/src/main/java/software/tnb/hashicorp/vault/resource/local/LocalHashicorpVault.java
+++ b/system-x/services/hashicorp-vault/src/main/java/software/tnb/hashicorp/vault/resource/local/LocalHashicorpVault.java
@@ -1,0 +1,58 @@
+package software.tnb.hashicorp.vault.resource.local;
+
+import software.tnb.common.deployment.Deployable;
+import software.tnb.hashicorp.vault.service.HashicorpVault;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.auto.service.AutoService;
+
+import java.util.Map;
+
+@AutoService(HashicorpVault.class)
+public class LocalHashicorpVault extends HashicorpVault implements Deployable {
+    private static final Logger LOG = LoggerFactory.getLogger(LocalHashicorpVault.class);
+    private HashicorpVaultContainer container;
+
+    @Override
+    public void deploy() {
+        LOG.info("Starting Hashicorp Vault");
+        container = new HashicorpVaultContainer(image(), Map.of("VAULT_DEV_ROOT_TOKEN_ID", account().token()), PORT);
+        container.start();
+        LOG.info("Hashicorp Vault container started");
+    }
+
+    @Override
+    public void undeploy() {
+        if (container != null) {
+            LOG.info("Stopping Hashicorp Vault container");
+            container.stop();
+        }
+    }
+
+    @Override
+    public void openResources() {
+
+    }
+
+    @Override
+    public void closeResources() {
+
+    }
+
+    @Override
+    public String host() {
+        return container.getHost();
+    }
+
+    @Override
+    public int port() {
+        return container.getMappedPort(PORT);
+    }
+
+    @Override
+    public String scheme() {
+        return "http";
+    }
+}

--- a/system-x/services/hashicorp-vault/src/main/java/software/tnb/hashicorp/vault/service/HashicorpVault.java
+++ b/system-x/services/hashicorp-vault/src/main/java/software/tnb/hashicorp/vault/service/HashicorpVault.java
@@ -1,0 +1,46 @@
+package software.tnb.hashicorp.vault.service;
+
+import software.tnb.common.deployment.WithDockerImage;
+import software.tnb.common.service.Service;
+import software.tnb.hashicorp.vault.account.HashicorpVaultAccount;
+import software.tnb.hashicorp.vault.validation.HashicorpVaultValidation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.vault.authentication.TokenAuthentication;
+import org.springframework.vault.client.VaultEndpoint;
+import org.springframework.vault.core.VaultTemplate;
+
+public abstract class HashicorpVault extends Service<HashicorpVaultAccount, VaultTemplate, HashicorpVaultValidation> implements WithDockerImage {
+    private static final Logger LOG = LoggerFactory.getLogger(HashicorpVault.class);
+
+    protected static final int PORT = 8200;
+
+    public abstract String host();
+
+    public abstract int port();
+
+    public abstract String scheme();
+
+    public String defaultImage() {
+        return "quay.io/rh_integration/hashicorp/vault:1.17";
+    }
+
+    @Override
+    public HashicorpVaultValidation validation() {
+        return new HashicorpVaultValidation(client());
+    }
+
+    @Override
+    protected VaultTemplate client() {
+        VaultEndpoint vaultEndpoint = new VaultEndpoint();
+        vaultEndpoint.setHost(host());
+        vaultEndpoint.setPort(port());
+        vaultEndpoint.setScheme(scheme());
+
+        return new VaultTemplate(
+            vaultEndpoint,
+            new TokenAuthentication(account().token())
+        );
+    }
+}

--- a/system-x/services/hashicorp-vault/src/main/java/software/tnb/hashicorp/vault/validation/HashicorpVaultValidation.java
+++ b/system-x/services/hashicorp-vault/src/main/java/software/tnb/hashicorp/vault/validation/HashicorpVaultValidation.java
@@ -1,0 +1,36 @@
+package software.tnb.hashicorp.vault.validation;
+
+import software.tnb.common.validation.Validation;
+
+import org.springframework.vault.core.VaultKeyValueOperations;
+import org.springframework.vault.core.VaultKeyValueOperationsSupport;
+import org.springframework.vault.core.VaultTemplate;
+import org.springframework.vault.support.VaultResponse;
+
+import java.util.Map;
+
+public class HashicorpVaultValidation implements Validation {
+    private VaultTemplate client;
+
+    public HashicorpVaultValidation(VaultTemplate client) {
+        this.client = client;
+    }
+
+    public void createSecret(String path, Map<String, Object> entry) {
+
+        VaultKeyValueOperations vaultKeyValueOperations = client.opsForKeyValue("secret", VaultKeyValueOperationsSupport.KeyValueBackend.versioned());
+        vaultKeyValueOperations.put(path, entry);
+    }
+
+    public Map<String, Object> readSecret(String path) {
+        VaultKeyValueOperations vaultKeyValueOperations = client.opsForKeyValue("secret", VaultKeyValueOperationsSupport.KeyValueBackend.versioned());
+        VaultResponse vaultResponse = vaultKeyValueOperations.get(path);
+
+        return vaultResponse.getData();
+    }
+
+    public void updateSecret(String path, Map<String, Object> entry) {
+        VaultKeyValueOperations vaultKeyValueOperations = client.opsForKeyValue("secret", VaultKeyValueOperationsSupport.KeyValueBackend.versioned());
+        vaultKeyValueOperations.patch(path, entry);
+    }
+}

--- a/system-x/services/pom.xml
+++ b/system-x/services/pom.xml
@@ -24,6 +24,7 @@
         <module>gitops</module>
         <module>graphql</module>
         <module>google</module>
+        <module>hashicorp-vault</module>
         <module>knative</module>
         <module>ldap</module>
         <module>slack</module>


### PR DESCRIPTION
For the OCP part we can try to implement the following guide https://github.com/jboss-fuse/apache-camel-on-ocp-best-practices/tree/main/examples/vault/hashicorp-vault/camel-quarkus/retrieval#setting-up-hashicorp-vault-instance

@avano do you think this is possible to implement that in TNB?