### PR TITLE
[otel] Update otel-collector config

### DIFF
--- a/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/service/configuration/OpenTelemetryCollectorConfiguration.java
+++ b/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/service/configuration/OpenTelemetryCollectorConfiguration.java
@@ -40,7 +40,7 @@ public class OpenTelemetryCollectorConfiguration extends ServiceConfiguration {
 
     public OpenTelemetryCollectorConfiguration withDefaultProcessors() {
         Map<String, Object> batch = new HashMap<>();
-        batch.put("send_batch_size", "10000");
+        batch.put("send_batch_size", 10000);
         batch.put("timeout", "10s");
         processors.put("batch", batch);
         return this;


### PR DESCRIPTION
to avoid startup error:

> Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):
> 
> error decoding 'processors': error reading configuration for "batch": decoding failed due to the following error(s):
> 
> 'send_batch_size' expected type 'uint32', got unconvertible type 'string', value: '10000'
> 
> Hint: Temporarily restore the previous behavior by disabling 
>       the `confmap.strictlyTypedInput` feature gate. More details at:
>       https://github.com/open-telemetry/opentelemetry-collector/issues/10552
> 2024/10/21 19:00:15 collector server run finished with error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):
> 
> error decoding 'processors': error reading configuration for "batch": decoding failed due to the following error(s):
> 
> 'send_batch_size' expected type 'uint32', got unconvertible type 'string', value: '10000'
> 
> Hint: Temporarily restore the previous behavior by disabling 
>       the `confmap.strictlyTypedInput` feature gate. More details at:
>       https://github.com/open-telemetry/opentelemetry-collector/issues/10552