### PR TITLE
Revert back minio version for IBM Z support

### DIFF
--- a/system-x/services/aws/s3/src/main/java/software/tnb/aws/s3/service/Minio.java
+++ b/system-x/services/aws/s3/src/main/java/software/tnb/aws/s3/service/Minio.java
@@ -47,6 +47,6 @@ public abstract class Minio extends AWSService<AWSAccount, S3Client, S3Validatio
 
     @Override
     public String defaultImage() {
-        return "quay.io/minio/minio:RELEASE.2024-10-13T13-34-11Z";
+        return "quay.io/minio/minio:RELEASE.2024-10-02T17-50-41Z";
     }
 }


### PR DESCRIPTION
Minio recently ended official support/builds for s390x. Temporarily reverting back minio version by 1 on tnb while we figure out new solution. 