### PR TITLE
Enable multi-arch build for hawtio-jbang image

### DIFF
--- a/system-x/services/hawtio/src/main/resources/hawtio-jbang/build.sh
+++ b/system-x/services/hawtio/src/main/resources/hawtio-jbang/build.sh
@@ -4,4 +4,4 @@ export HAWTIO_REPOS_TAG=hawtio-4.2.0
 #the version should be from https://github.com/hawtio/hawtio/blob/hawtio-$HAWTIO_REPOS_TAG/hawtio-jbang/dist/HawtioJBang.java
 export HAWTIO_VERSION=4.1.0
 
-podman build --build-arg HAWTIO_REPOS_TAG=$HAWTIO_REPOS_TAG . -t quay.io/rh_integration/hawtio-jbang:$HAWTIO_VERSION
+docker buildx build --build-arg HAWTIO_REPOS_TAG=$HAWTIO_REPOS_TAG -t quay.io/rh_integration/hawtio-jbang:$HAWTIO_VERSION --platform linux/amd64,linux/arm64,linux/ppc64le,linux/s390x --provenance=false --push .


### PR DESCRIPTION
Adding multi-arch build for new hawtio-jbang image, includes arm64, ppc64le and s390x. 