### PR TITLE
opentelemetry system-x: Make otel collector configurable

### DIFF
--- a/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/resource/local/LocalOpenTelemetryCollector.java
+++ b/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/resource/local/LocalOpenTelemetryCollector.java
@@ -9,8 +9,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.auto.service.AutoService;
 
-import java.util.Optional;
-
 @AutoService(OpenTelemetryCollector.class)
 public class LocalOpenTelemetryCollector extends OpenTelemetryCollector implements Deployable, WithDockerImage {
     private static final Logger LOG = LoggerFactory.getLogger(LocalOpenTelemetryCollector.class);
@@ -47,12 +45,12 @@ public class LocalOpenTelemetryCollector extends OpenTelemetryCollector implemen
 
     @Override
     public String getGrpcEndpoint() {
-        return "http://localhost:" + Optional.ofNullable(container).map(c -> c.getMappedPort(4317)).orElse(4317);
+        return "http://localhost:" + getConfiguration().getGrpcReceiverPort();
     }
 
     @Override
     public String getHttpEndpoint() {
-        return "http://localhost:" + Optional.ofNullable(container).map(c -> c.getMappedPort(4318)).orElse(4318);
+        return "http://localhost:" + getConfiguration().getHttpReceiverPort();
     }
 
     @Override

--- a/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/resource/local/OpenTelemetryCollectorContainer.java
+++ b/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/resource/local/OpenTelemetryCollectorContainer.java
@@ -21,7 +21,7 @@ public class OpenTelemetryCollectorContainer extends GenericContainer<OpenTeleme
         super(image);
         withFileSystemBind(CONF_PATH.toAbsolutePath().toString(), "/conf", BindMode.READ_ONLY);
         setCommandParts(new String[]{"--config=/conf/collector.yaml"});
-        withExposedPorts(4317, 4318);
+        withNetworkMode("host");
         waitingFor(Wait.forLogMessage(".*Everything is ready. Begin running and processing data.*", 1)
             .withStartupTimeout(Duration.ofSeconds(20)));
 

--- a/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/resource/openshift/OpenshiftOpenTelemetryCollector.java
+++ b/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/resource/openshift/OpenshiftOpenTelemetryCollector.java
@@ -82,12 +82,12 @@ public class OpenshiftOpenTelemetryCollector extends OpenTelemetryCollector impl
 
     @Override
     public String getGrpcEndpoint() {
-        return getHeadlessEndpoint() + ":4317";
+        return getHeadlessEndpoint() + ":" + getConfiguration().getGrpcReceiverPort();
     }
 
     @Override
     public String getHttpEndpoint() {
-        return getHeadlessEndpoint() + ":4318";
+        return getHeadlessEndpoint() + ":" + getConfiguration().getHttpReceiverPort();
     }
 
     private String getHeadlessEndpoint() {

--- a/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/service/OpenTelemetryCollector.java
+++ b/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/service/OpenTelemetryCollector.java
@@ -16,6 +16,6 @@ public abstract class OpenTelemetryCollector extends ConfigurableService<NoAccou
 
     @Override
     protected void defaultConfiguration() {
-        getConfiguration().withReplicas(1);
+        getConfiguration().withReplicas(1).withActuatorHealthCheckExcluded();
     }
 }


### PR DESCRIPTION
to make OpenTelemetry collector work with Jaeger, it needs to be configurable on receiver ports (since both systems use the same ports)