### PR TITLE
[Postgres] Attempt to fix startup issue

### DIFF
--- a/system-x/services/db/postgresql/src/main/java/software/tnb/db/postgres/resource/local/LocalPostgreSQL.java
+++ b/system-x/services/db/postgresql/src/main/java/software/tnb/db/postgres/resource/local/LocalPostgreSQL.java
@@ -10,7 +10,8 @@ import com.google.auto.service.AutoService;
 
 @AutoService(PostgreSQL.class)
 public class LocalPostgreSQL extends PostgreSQL implements Deployable {
-    private final LocalDB localDb = new LocalDB(this, PORT, Wait.forLogMessage(".*Future log output will appear in directory.*", 2));
+    private final LocalDB localDb = new LocalDB(this, PORT,
+        Wait.forSuccessfulCommand("[ $(cat /var/lib/pgsql/data/userdata/log/*.log | grep \"ready to accept\" | wc -l) -eq 2 ]"));
 
     @Override
     public String host() {


### PR DESCRIPTION
Occasionally the startup fails with "PSQLException: FATAL: the database system is starting up". Since after starting up the container logs the messages only to the file, check if it claims being ready to accept the connections in the log file.