### PR TITLE
Add IBM power supported elasticSearch and OpenSearch images 

### DIFF
--- a/system-x/services/search-engine/elasticsearch/src/main/java/software/tnb/elasticsearch/service/Elasticsearch.java
+++ b/system-x/services/search-engine/elasticsearch/src/main/java/software/tnb/elasticsearch/service/Elasticsearch.java
@@ -10,6 +10,7 @@ import org.testcontainers.utility.Base58;
 
 import java.io.Closeable;
 import java.util.Map;
+import org.apache.commons.lang3.SystemUtils;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
@@ -52,7 +53,11 @@ public abstract class Elasticsearch extends Search<ElasticsearchClient> {
 
     @Override
     public String defaultImage() {
-        return "docker.elastic.co/elasticsearch/elasticsearch:" + Elasticsearch.version();
+        if ("ppc64le".equals(SystemUtils.OS_ARCH)) {
+            return "icr.io/ppc64le-oss/elasticsearch-ppc64le:7.17.10";
+        }else{
+            return "docker.elastic.co/elasticsearch/elasticsearch:" + Elasticsearch.version();
+	}
     }
 
     public static String version() {

--- a/system-x/services/search-engine/opensearch/src/main/java/software/tnb/opensearch/service/Opensearch.java
+++ b/system-x/services/search-engine/opensearch/src/main/java/software/tnb/opensearch/service/Opensearch.java
@@ -75,7 +75,6 @@ public abstract class Opensearch extends Search<OpenSearchClient> {
 
     public String containerStartRegex() {
         return ".*Node started.*";
-        //return ".*ML configuration initialized successfully.*";
     }
 
     public Map<String, String> containerEnv() {

--- a/system-x/services/search-engine/opensearch/src/main/java/software/tnb/opensearch/service/Opensearch.java
+++ b/system-x/services/search-engine/opensearch/src/main/java/software/tnb/opensearch/service/Opensearch.java
@@ -51,7 +51,6 @@ public abstract class Opensearch extends Search<OpenSearchClient> {
 
     @Override
     public String defaultImage() {
-        //return "quay.io/fuse_qe/opensearch:" + version();
         if ("ppc64le".equals(SystemUtils.OS_ARCH)) {
             return "icr.io/ppc64le-oss/opensearch-ppc64le:2.12.0";
         }else{

--- a/system-x/services/search-engine/opensearch/src/main/java/software/tnb/opensearch/service/Opensearch.java
+++ b/system-x/services/search-engine/opensearch/src/main/java/software/tnb/opensearch/service/Opensearch.java
@@ -13,6 +13,7 @@ import org.testcontainers.utility.Base58;
 
 import java.io.Closeable;
 import java.util.Map;
+import org.apache.commons.lang3.SystemUtils;
 
 public abstract class Opensearch extends Search<OpenSearchClient> {
     private static final String CLUSTER_NAME = "tnb-os";
@@ -50,7 +51,12 @@ public abstract class Opensearch extends Search<OpenSearchClient> {
 
     @Override
     public String defaultImage() {
-        return "quay.io/fuse_qe/opensearch:" + version();
+        //return "quay.io/fuse_qe/opensearch:" + version();
+        if ("ppc64le".equals(SystemUtils.OS_ARCH)) {
+            return "icr.io/ppc64le-oss/opensearch-ppc64le:2.12.0";
+        }else{
+            return "quay.io/fuse_qe/opensearch:" + version();
+        }
     }
 
     public static String version() {
@@ -69,7 +75,8 @@ public abstract class Opensearch extends Search<OpenSearchClient> {
     }
 
     public String containerStartRegex() {
-        return ".*ML configuration initialized successfully.*";
+        return ".*Node started.*";
+        //return ".*ML configuration initialized successfully.*";
     }
 
     public Map<String, String> containerEnv() {


### PR DESCRIPTION
Description: ElasticSearch and OpenSearch images are now available in icr.io. 
OpenSearch image is not ML supported because of license issue hence need to update string in _containerStartRegex() function.
The builds are verified on both x86 and IBM Power platform with latest CSB 4.8. release

