### PR TITLE
[Config] Store microprofile properties in TreeMap so they are ordered…

### DIFF
--- a/common/src/main/java/software/tnb/common/config/source/TestPropertiesConfigSource.java
+++ b/common/src/main/java/software/tnb/common/config/source/TestPropertiesConfigSource.java
@@ -9,17 +9,17 @@ import org.slf4j.LoggerFactory;
 import com.google.auto.service.AutoService;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Defines a ConfigSource that loads the properties from a properties file defined in "test.properties" system property.
  * <p/>
  * This ConfigSource has the highest priority of all config sources (ordinal 500), that means that the values in test.properties take precedence
- *  over environment and system properties defined in any way.
+ * over environment and system properties defined in any way.
  * <p/>
  * Note for the future: If we ever wanted to achieve a hierarchy like this: values in pom.xml -> test.properties -> system properties, then two
- *  things need to happen:
+ * things need to happen:
  * - pass the properties from pom.xml as environment variables, not as system properties
  * - lower the ordinal of this class to a number between 300 and 400
  */
@@ -28,7 +28,7 @@ public class TestPropertiesConfigSource implements ConfigSource {
     private static final Logger LOG = LoggerFactory.getLogger(TestPropertiesConfigSource.class);
     private static final String TEST_PROPERTIES = "test.properties";
 
-    private final Map<String, String> properties = new HashMap<>();
+    private final Map<String, String> properties = new TreeMap<>();
 
     public TestPropertiesConfigSource() {
         File testProperties = new File(System.getProperty(TEST_PROPERTIES, "test.properties"));


### PR DESCRIPTION
… on output

When using test.properties with longer list of properties it is useful to have ordered output of loaded properties so they are grouped. 