### PR TITLE
Minor test.properties logging and Horreum tweak 

### DIFF
--- a/common/src/main/java/software/tnb/common/config/source/TestPropertiesConfigSource.java
+++ b/common/src/main/java/software/tnb/common/config/source/TestPropertiesConfigSource.java
@@ -9,17 +9,17 @@ import org.slf4j.LoggerFactory;
 import com.google.auto.service.AutoService;
 
 import java.io.File;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Defines a ConfigSource that loads the properties from a properties file defined in "test.properties" system property.
  * <p/>
  * This ConfigSource has the highest priority of all config sources (ordinal 500), that means that the values in test.properties take precedence
- *  over environment and system properties defined in any way.
+ * over environment and system properties defined in any way.
  * <p/>
  * Note for the future: If we ever wanted to achieve a hierarchy like this: values in pom.xml -> test.properties -> system properties, then two
- *  things need to happen:
+ * things need to happen:
  * - pass the properties from pom.xml as environment variables, not as system properties
  * - lower the ordinal of this class to a number between 300 and 400
  */
@@ -28,7 +28,7 @@ public class TestPropertiesConfigSource implements ConfigSource {
     private static final Logger LOG = LoggerFactory.getLogger(TestPropertiesConfigSource.class);
     private static final String TEST_PROPERTIES = "test.properties";
 
-    private final Map<String, String> properties = new HashMap<>();
+    private final Map<String, String> properties = new TreeMap<>();
 
     public TestPropertiesConfigSource() {
         File testProperties = new File(System.getProperty(TEST_PROPERTIES, "test.properties"));

--- a/system-x/services/horreum/src/main/java/software/tnb/horreum/configuration/HorreumConfiguration.java
+++ b/system-x/services/horreum/src/main/java/software/tnb/horreum/configuration/HorreumConfiguration.java
@@ -15,6 +15,7 @@ public class HorreumConfiguration extends Configuration {
     public static final String REQUEST_LOG_ENABLED = "horreum.request.log.enabled";
     public static final String FINGERPRINT_NAME = "horreum.fingerprint.name";
     public static final String TESTRUN_DESCRIPTION = "horreum.testrun.description";
+    public static final String HORREUM_UPLOAD_DISABLED = "horreum.upload.disabled";
 
     public static String getUrl() {
         return getProperty(URL);
@@ -50,5 +51,9 @@ public class HorreumConfiguration extends Configuration {
 
     public static Optional<String> getFingerprintName() {
         return Optional.ofNullable(getProperty(FINGERPRINT_NAME));
+    }
+
+    public static boolean isUploadDisabled() {
+        return Boolean.parseBoolean(getProperty(HORREUM_UPLOAD_DISABLED, "false"));
     }
 }

--- a/system-x/services/horreum/src/main/java/software/tnb/horreum/validation/HorreumValidation.java
+++ b/system-x/services/horreum/src/main/java/software/tnb/horreum/validation/HorreumValidation.java
@@ -76,13 +76,17 @@ public class HorreumValidation implements Validation {
             LOG.info("Horreum upload request:");
             prettyPrinter.printRequest(uploadCall.request());
         }
-        Type responseType = new TypeToken<String>() {
-        }.getType();
-        ApiResponse<String> horreumResp = runApi.getApiClient().execute(uploadCall, responseType);
-        if (HorreumConfiguration.isRequestLogEnabled()) {
-            LOG.info("Horreum upload response: ");
-            prettyPrinter.printResponse(horreumResp);
+        if (!HorreumConfiguration.isUploadDisabled()) {
+            Type responseType = new TypeToken<String>() {
+            }.getType();
+            ApiResponse<String> horreumResp = runApi.getApiClient().execute(uploadCall, responseType);
+            if (HorreumConfiguration.isRequestLogEnabled()) {
+                LOG.info("Horreum upload response: ");
+                prettyPrinter.printResponse(horreumResp);
+            }
+            return horreumResp.getData();
+        } else {
+            return "horreum.upload.disabled=true -> results upload skipped";
         }
-        return horreumResp.getData();
     }
 }


### PR DESCRIPTION
[Config] When using test.properties with longer list of properties it is useful to have ordered output of loaded properties so they are grouped.

[Horreum] Disable horreum test data upload but keep horreum extension doing stuff. 