### PR TITLE
system-x-jira: Make the generated client configurable

### DIFF
--- a/system-x/services/jira/README.md
+++ b/system-x/services/jira/README.md
@@ -5,3 +5,7 @@ folder [jira-v3.v3.formatted.json](src%2Fmain%2Fresources%2Fjira-v3.v3.formatted
 Thanks to that, we don't need all generated resources (~around 750classes) in the source code repository.
 The classes are generated during the compile phase into target/generated-sources.
 Due to that, the IDE will show unresolved import errors until you run `mvn clean compile` in the `system-x-jira` package.
+
+# How do I need to use Jira Cloud?
+
+The `validation` has been implemented based on [Jira cloud](https://www.atlassian.com/try/cloud/) creating a base project and adding `Bug` issue type, then updating it adding `Priority` field.

--- a/system-x/services/jira/pom.xml
+++ b/system-x/services/jira/pom.xml
@@ -83,15 +83,15 @@
                         <configuration>
                             <inputSpec>${project.basedir}/src/main/resources/jira-v3.v3.formatted.json</inputSpec>
                             <generatorName>java</generatorName>
+                            <generateModelTests>false</generateModelTests>
+                            <generateApiTests>false</generateApiTests>
                             <configOptions>
                                 <apiPackage>software.tnb.jira.validation.generated.api</apiPackage>
                                 <modelPackage>software.tnb.jira.validation.generated.model</modelPackage>
                                 <invokerPackage>software.tnb.jira.validation.generated</invokerPackage>
                                 <groupId>${project.groupId}</groupId>
-                                <artifactId>${project.artifactId}</artifactId>
+                                <artifactId>${project.artifactId}-generated</artifactId>
                                 <artifactVersion>${project.version}</artifactVersion>
-                                <generateModelTests>false</generateModelTests>
-                                <generateApiTests>false</generateApiTests>
                                 <useJakartaEe>true</useJakartaEe>
                                 <openApiNullable>false</openApiNullable>
                             </configOptions>

--- a/system-x/services/jira/src/main/java/software/tnb/jira/account/JiraAccount.java
+++ b/system-x/services/jira/src/main/java/software/tnb/jira/account/JiraAccount.java
@@ -7,10 +7,6 @@ public class JiraAccount implements Account, WithId {
     private String jira_url;
     private String username;
     private String password;
-    private String private_key;
-    private String access_token;
-    private String consumer_key;
-    private String verification_code;
 
     @Override
     public String credentialsId() {
@@ -39,37 +35,5 @@ public class JiraAccount implements Account, WithId {
 
     public void setPassword(String password) {
         this.password = password;
-    }
-
-    public String getPrivateKey() {
-        return private_key;
-    }
-
-    public void setPrivate_key(final String private_key) {
-        this.private_key = private_key;
-    }
-
-    public String getAccessToken() {
-        return access_token;
-    }
-
-    public void setAccess_token(final String access_token) {
-        this.access_token = access_token;
-    }
-
-    public String getConsumerKey() {
-        return consumer_key;
-    }
-
-    public void setConsumer_key(final String consumer_key) {
-        this.consumer_key = consumer_key;
-    }
-
-    public String getVerificationCode() {
-        return verification_code;
-    }
-
-    public void setVerification_code(final String verification_code) {
-        this.verification_code = verification_code;
     }
 }

--- a/system-x/services/jira/src/main/java/software/tnb/jira/client/ConfigurableApiClient.java
+++ b/system-x/services/jira/src/main/java/software/tnb/jira/client/ConfigurableApiClient.java
@@ -1,0 +1,20 @@
+package software.tnb.jira.client;
+
+import software.tnb.jira.validation.generated.ApiClient;
+import software.tnb.jira.validation.generated.model.Project;
+
+public class ConfigurableApiClient extends ApiClient {
+
+    public ConfigurableApiClient() {
+        super();
+        configureAdditionalFields();
+    }
+
+    /**
+     * The fields coming from REST API response, but not in the Java models, without this, the validation fails
+     * even if the gson is lenient, since the validation is performed after the deserialization
+     */
+    private void configureAdditionalFields() {
+        Project.openapiFields.add("entityId");
+    }
+}

--- a/system-x/services/jira/src/main/java/software/tnb/jira/service/Jira.java
+++ b/system-x/services/jira/src/main/java/software/tnb/jira/service/Jira.java
@@ -2,9 +2,9 @@ package software.tnb.jira.service;
 
 import software.tnb.common.service.Service;
 import software.tnb.jira.account.JiraAccount;
+import software.tnb.jira.client.ConfigurableApiClient;
 import software.tnb.jira.validation.JiraValidation;
 import software.tnb.jira.validation.generated.ApiClient;
-import software.tnb.jira.validation.generated.Configuration;
 
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -22,7 +22,7 @@ public class Jira extends Service<JiraAccount, ApiClient, JiraValidation> {
         if (client == null) {
             LOG.debug("Creating new JiraRest client");
 
-            client = Configuration.getDefaultApiClient();
+            client = new ConfigurableApiClient();
             client.setBasePath(account().getJiraUrl());
             client.setUsername(account().getUsername());
             client.setPassword(account().getPassword());


### PR DESCRIPTION
those changes are necessary to avoid validation issues, since cloud REST API returns responses with `entityId` field not present on Project model causing validation errors during the deserialization