### PR TITLE
ibm-mq: Allow current cipher suite

### DIFF
--- a/system-x/services/jms/ibm-mq/src/main/java/software/tnb/jms/ibm/mq/service/IBMMQ.java
+++ b/system-x/services/jms/ibm-mq/src/main/java/software/tnb/jms/ibm/mq/service/IBMMQ.java
@@ -32,7 +32,8 @@ public abstract class IBMMQ extends ConfigurableService<IBMMQAccount, Connection
         return Map.of(
             "LICENSE", "accept",
             "MQ_QMGR_NAME", account().queueManager(),
-            "MQ_APP_PASSWORD", account().password()
+            "MQ_APP_PASSWORD", account().password(),
+            "AMQ_SSL_WEAK_CIPHER_ENABLE", SSLCIPHERSUITE
         );
     }
 


### PR DESCRIPTION
since the IBM MQ has been updated in https://github.com/tnb-software/TNB/pull/1404 the policies have been updated and we need to allow the used cipher suite