### PR TITLE
system-x: Adds operatorhub-subscription

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -406,6 +406,11 @@
             </dependency>
             <dependency>
                 <groupId>software.tnb</groupId>
+                <artifactId>system-x-operatorhub-subscription</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>software.tnb</groupId>
                 <artifactId>system-x-parent</artifactId>
                 <version>1.0-SNAPSHOT</version>
             </dependency>

--- a/system-x/services/all/pom.xml
+++ b/system-x/services/all/pom.xml
@@ -295,6 +295,10 @@
         </dependency>
         <dependency>
             <groupId>software.tnb</groupId>
+            <artifactId>system-x-operatorhub-subscription</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.tnb</groupId>
             <artifactId>system-x-postgresql</artifactId>
         </dependency>
         <dependency>

--- a/system-x/services/operatorhub-subscription/pom.xml
+++ b/system-x/services/operatorhub-subscription/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>software.tnb</groupId>
+        <artifactId>system-x-services</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>system-x-operatorhub-subscription</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <name>TNB :: System-X :: Services :: OperatorHub Subscription</name>
+    <description>To install a subscription using OperatorHub</description>
+
+</project>

--- a/system-x/services/operatorhub-subscription/src/main/java/software/tnb/operatorhub/resource/openshift/OpenshiftOperatorHubSubscription.java
+++ b/system-x/services/operatorhub-subscription/src/main/java/software/tnb/operatorhub/resource/openshift/OpenshiftOperatorHubSubscription.java
@@ -1,0 +1,135 @@
+package software.tnb.operatorhub.resource.openshift;
+
+import software.tnb.common.deployment.ReusableOpenshiftDeployable;
+import software.tnb.common.deployment.WithOperatorHub;
+import software.tnb.common.openshift.OpenshiftClient;
+import software.tnb.operatorhub.service.OperatorHubSubscription;
+
+import com.google.auto.service.AutoService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.Pod;
+
+@AutoService(OperatorHubSubscription.class)
+public class OpenshiftOperatorHubSubscription extends OperatorHubSubscription implements ReusableOpenshiftDeployable, WithOperatorHub {
+
+    @Override
+    protected void defaultConfiguration() {
+        getConfiguration().operatorCatalog(WithOperatorHub.super.operatorCatalog())
+            .operatorCatalogNamespace(WithOperatorHub.super.operatorCatalogNamespace())
+            .operatorChannel(WithOperatorHub.super.operatorChannel())
+            .subscriptionName(WithOperatorHub.super.subscriptionName())
+            .targetNamespace(WithOperatorHub.super.targetNamespace())
+            .clusterWide(WithOperatorHub.super.clusterWide())
+            .operatorEnvVariables(Optional.ofNullable(WithOperatorHub.super.getOperatorEnvVariables())
+                .map(this::toMap).orElse(null))
+            .podSelector(Map.of());
+    }
+
+    @Override
+    public void cleanup() {
+
+    }
+
+    @Override
+    public void create() {
+        createSubscription();
+    }
+
+    @Override
+    public boolean isReady() {
+        return !isPodSelectorSet() || ReusableOpenshiftDeployable.super.isReady();
+    }
+
+    @Override
+    public boolean isDeployed() {
+        return OpenshiftClient.get().operatorHub().subscriptions().inNamespace(targetNamespace()).list()
+            .getItems().stream().anyMatch(subscription -> subscriptionName().equals(subscription.getMetadata().getName()));
+    }
+
+    @Override
+    public Predicate<Pod> podSelector() {
+        return pod -> isPodSelectorSet() && OpenshiftClient.get().hasLabels(pod, getConfiguration().getPodSelector());
+    }
+
+    @Override
+    public void undeploy() {
+        deleteSubscription(() -> !isPodSelectorSet()
+            || OpenshiftClient.get().getLabeledPods(getConfiguration().getPodSelector()).isEmpty());
+    }
+
+    @Override
+    public void openResources() {
+
+    }
+
+    @Override
+    public void closeResources() {
+
+    }
+
+    @Override
+    public String operatorName() {
+        return getConfiguration().getOperatorName();
+    }
+
+    @Override
+    public String operatorCatalog() {
+        return getConfiguration().getOperatorCatalog();
+    }
+
+    @Override
+    public String operatorCatalogNamespace() {
+        return getConfiguration().getOperatorCatalogNamespace();
+    }
+
+    @Override
+    public String operatorChannel() {
+        return getConfiguration().getOperatorChannel();
+    }
+
+    @Override
+    public String subscriptionName() {
+        return getConfiguration().getSubscriptionName();
+    }
+
+    @Override
+    public String targetNamespace() {
+        return getConfiguration().getTargetNamespace();
+    }
+
+    @Override
+    public boolean clusterWide() {
+        return WithOperatorHub.super.clusterWide();
+    }
+
+    @Override
+    public List<EnvVar> getOperatorEnvVariables() {
+        return toList(getConfiguration().getOperatorEnvVariables());
+    }
+
+    private boolean isPodSelectorSet() {
+        return getConfiguration().getPodSelector() != null && !getConfiguration().getPodSelector().isEmpty();
+    }
+
+    private Map<String, String> toMap(List<EnvVar> envVars) {
+        return Optional.ofNullable(envVars)
+            .map(vars -> vars.stream().collect(Collectors.toMap(EnvVar::getName,
+                EnvVar::getValue)))
+            .orElse(null);
+    }
+
+    private List<EnvVar> toList(Map<String, String> envMap) {
+        return Optional.ofNullable(envMap)
+            .map(em -> em.entrySet().stream()
+                .map(entry -> new EnvVar(entry.getKey(), entry.getValue(), null))
+                .collect(Collectors.toList()))
+            .orElse(null);
+    }
+}

--- a/system-x/services/operatorhub-subscription/src/main/java/software/tnb/operatorhub/service/OperatorHubSubscription.java
+++ b/system-x/services/operatorhub-subscription/src/main/java/software/tnb/operatorhub/service/OperatorHubSubscription.java
@@ -1,0 +1,11 @@
+package software.tnb.operatorhub.service;
+
+import software.tnb.common.account.NoAccount;
+import software.tnb.common.client.NoClient;
+import software.tnb.common.service.ConfigurableService;
+import software.tnb.common.validation.NoValidation;
+import software.tnb.operatorhub.service.configuration.OperatorHubSubscriptionConfiguration;
+
+public abstract class OperatorHubSubscription extends ConfigurableService<NoAccount, NoClient, NoValidation, OperatorHubSubscriptionConfiguration> {
+
+}

--- a/system-x/services/operatorhub-subscription/src/main/java/software/tnb/operatorhub/service/configuration/OperatorHubSubscriptionConfiguration.java
+++ b/system-x/services/operatorhub-subscription/src/main/java/software/tnb/operatorhub/service/configuration/OperatorHubSubscriptionConfiguration.java
@@ -1,0 +1,99 @@
+package software.tnb.operatorhub.service.configuration;
+
+import software.tnb.common.service.configuration.ServiceConfiguration;
+
+import java.util.Map;
+
+public class OperatorHubSubscriptionConfiguration extends ServiceConfiguration {
+
+    private static final String OH_OPERATOR_NAME = "oh.operator.name";
+    private static final String OH_OPERATOR_CATALOG = "oh.operator.catalog";
+    private static final String OH_OPERATOR_CATALOG_NAMESPACE = "oh.operator.catalog.namespace";
+    private static final String OH_OPERATOR_CHANNEL = "oh.operator.channel";
+    private static final String OH_SUBSCRIPTION_NAME = "oh.subscription.name";
+    private static final String OH_SUBSCRIPTION_NAMESPACE = "oh.subscription.namespace";
+    private static final String OH_SUBSCRIPTION_CLUSTER_WIDE = "oh.subscription.clusterwide";
+    private static final String OH_OPERATOR_ENV_VARS = "oh.operator.env.vars";
+    private static final String OH_OPERATOR_POD_SELECTOR = "oh.operator.pod.selector";
+
+    public OperatorHubSubscriptionConfiguration operatorName(String operatorName) {
+        set(OH_OPERATOR_NAME, operatorName);
+        return this;
+    }
+
+    public String getOperatorName() {
+        return get(OH_OPERATOR_NAME, String.class);
+    }
+
+    public OperatorHubSubscriptionConfiguration operatorCatalog(String operatorCatalog) {
+        set(OH_OPERATOR_CATALOG, operatorCatalog);
+        return this;
+    }
+
+    public String getOperatorCatalog() {
+        return get(OH_OPERATOR_CATALOG, String.class);
+    }
+
+    public OperatorHubSubscriptionConfiguration operatorCatalogNamespace(String operatorCatalogNamespace) {
+        set(OH_OPERATOR_CATALOG_NAMESPACE, operatorCatalogNamespace);
+        return this;
+    }
+
+    public String getOperatorCatalogNamespace() {
+        return get(OH_OPERATOR_CATALOG_NAMESPACE, String.class);
+    }
+
+    public OperatorHubSubscriptionConfiguration operatorChannel(String operatorChannel) {
+        set(OH_OPERATOR_CHANNEL, operatorChannel);
+        return this;
+    }
+
+    public String getOperatorChannel() {
+        return get(OH_OPERATOR_CHANNEL, String.class);
+    }
+
+    public OperatorHubSubscriptionConfiguration subscriptionName(String subscriptionName) {
+        set(OH_SUBSCRIPTION_NAME, subscriptionName);
+        return this;
+    }
+
+    public String getSubscriptionName() {
+        return get(OH_SUBSCRIPTION_NAME, String.class);
+    }
+
+    public OperatorHubSubscriptionConfiguration targetNamespace(String targetNamespace) {
+        set(OH_SUBSCRIPTION_NAMESPACE, targetNamespace);
+        return this;
+    }
+
+    public String getTargetNamespace() {
+        return get(OH_SUBSCRIPTION_NAMESPACE, String.class);
+    }
+
+    public OperatorHubSubscriptionConfiguration clusterWide(boolean clusterWide) {
+        set(OH_SUBSCRIPTION_CLUSTER_WIDE, clusterWide);
+        return this;
+    }
+
+    public boolean isClusterWide() {
+        return get(OH_SUBSCRIPTION_CLUSTER_WIDE, Boolean.class);
+    }
+
+    public OperatorHubSubscriptionConfiguration operatorEnvVariables(Map<String, String> env) {
+        set(OH_OPERATOR_ENV_VARS, env);
+        return this;
+    }
+
+    public Map<String, String> getOperatorEnvVariables() {
+        return get(OH_OPERATOR_ENV_VARS, Map.class);
+    }
+
+    public OperatorHubSubscriptionConfiguration podSelector(Map<String, String> labels) {
+        set(OH_OPERATOR_POD_SELECTOR, labels);
+        return this;
+    }
+
+    public Map<String, String> getPodSelector() {
+        return get(OH_OPERATOR_POD_SELECTOR, Map.class);
+    }
+}

--- a/system-x/services/pom.xml
+++ b/system-x/services/pom.xml
@@ -51,6 +51,7 @@
         <module>lra-coordinator</module>
         <module>mllp</module>
         <module>opentelemetry</module>
+        <module>operatorhub-subscription</module>
         <module>webhook</module>
         <module>splunk</module>
         <module>microsoft</module>


### PR DESCRIPTION
Adds the feature to install just a subscription (the same as installing the Operator from the OperatorHub), it can be used like:
```
    @RegisterExtension
    public static OperatorHubSubscription operatorHubSubscription = ServiceFactory.create(OperatorHubSubscription.class
        , config -> config.operatorName("amq-streams")
            .podSelector(Map.of("name", "amq-streams-cluster-operator")));
```
