### PR TITLE
system-x-sql: Makes the service configurable via env variables

### DIFF
--- a/system-x/services/db/common/src/main/java/software/tnb/db/common/local/DBContainer.java
+++ b/system-x/services/db/common/src/main/java/software/tnb/db/common/local/DBContainer.java
@@ -12,7 +12,7 @@ public class DBContainer extends GenericContainer<DBContainer> {
         super(service.image());
         this.port = port;
         withExposedPorts(port);
-        withEnv(service.containerEnvironment());
+        withEnv(service.getConfiguration().getEnvironmentVariables());
         waitingFor(waitStrategy);
         // with podman the startup occasionally fails and adding this seems to help
         withStartupAttempts(2);

--- a/system-x/services/db/common/src/main/java/software/tnb/db/common/local/LocalDB.java
+++ b/system-x/services/db/common/src/main/java/software/tnb/db/common/local/LocalDB.java
@@ -12,17 +12,19 @@ import java.util.List;
 public class LocalDB implements Deployable {
     private static final Logger LOG = LoggerFactory.getLogger(LocalDB.class);
     private final SQL sqlService;
-    private final DBContainer container;
+    private final WaitStrategy waitStrategy;
     private final int port;
+    private DBContainer container;
 
     public LocalDB(SQL sqlService, int port, WaitStrategy waitStrategy) {
         this.sqlService = sqlService;
         this.port = port;
-        this.container = new DBContainer(sqlService, port, waitStrategy);
+        this.waitStrategy = waitStrategy;
     }
 
     @Override
     public void deploy() {
+        this.container = new DBContainer(sqlService, port, waitStrategy);
         LOG.info("Starting " + sqlService.name() + " container");
         container.start();
         LOG.info(sqlService.name() + " container started");

--- a/system-x/services/db/common/src/main/java/software/tnb/db/common/openshift/OpenshiftDB.java
+++ b/system-x/services/db/common/src/main/java/software/tnb/db/common/openshift/OpenshiftDB.java
@@ -63,7 +63,7 @@ public class OpenshiftDB implements OpenshiftDeployable, WithName {
         OpenshiftClient.get().createDeployment(Map.of(
             "name", name(),
             "image", sqlService.image(),
-            "env", sqlService.containerEnvironment(),
+            "env", sqlService.getConfiguration().getEnvironmentVariables(),
             "ports", ports,
             "readinessProbe", probe
         ), builder -> builder

--- a/system-x/services/db/common/src/main/java/software/tnb/db/common/service/SQL.java
+++ b/system-x/services/db/common/src/main/java/software/tnb/db/common/service/SQL.java
@@ -6,9 +6,10 @@ import software.tnb.common.config.OpenshiftConfiguration;
 import software.tnb.common.deployment.WithDockerImage;
 import software.tnb.common.deployment.WithExternalHostname;
 import software.tnb.common.deployment.WithName;
-import software.tnb.common.service.Service;
+import software.tnb.common.service.ConfigurableService;
 import software.tnb.common.util.ReflectionUtil;
 import software.tnb.db.common.account.SQLAccount;
+import software.tnb.db.common.service.configuration.SQLConfiguration;
 import software.tnb.db.common.validation.SQLValidation;
 
 import org.slf4j.Logger;
@@ -16,7 +17,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Map;
 
-public abstract class SQL extends Service<SQLAccount, NoClient, SQLValidation> implements WithName, WithExternalHostname, WithDockerImage {
+public abstract class SQL extends ConfigurableService<SQLAccount, NoClient, SQLValidation, SQLConfiguration>
+    implements WithName, WithExternalHostname, WithDockerImage {
     private static final Logger LOG = LoggerFactory.getLogger(SQL.class);
 
     protected abstract Class<? extends SQLAccount> accountClass();
@@ -73,5 +75,10 @@ public abstract class SQL extends Service<SQLAccount, NoClient, SQLValidation> i
 
     public String name() {
         return ReflectionUtil.getSuperClassName(this.getClass());
+    }
+
+    @Override
+    protected void defaultConfiguration() {
+        getConfiguration().environmentVariables(containerEnvironment());
     }
 }

--- a/system-x/services/db/common/src/main/java/software/tnb/db/common/service/configuration/SQLConfiguration.java
+++ b/system-x/services/db/common/src/main/java/software/tnb/db/common/service/configuration/SQLConfiguration.java
@@ -1,0 +1,27 @@
+package software.tnb.db.common.service.configuration;
+
+import software.tnb.common.service.configuration.ServiceConfiguration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SQLConfiguration extends ServiceConfiguration {
+
+    private static final String ENV_VARIABLES = "sql.env.vars";
+
+    public SQLConfiguration environmentVariables(Map<String, String> env) {
+        set(ENV_VARIABLES, env);
+        return this;
+    }
+
+    public SQLConfiguration addEnvironmentVariable(String name, String value) {
+        Map<String, String> env = new HashMap<>(getEnvironmentVariables());
+        env.put(name, value);
+        environmentVariables(env);
+        return this;
+    }
+
+    public Map<String, String> getEnvironmentVariables() {
+        return get(ENV_VARIABLES, Map.class);
+    }
+}


### PR DESCRIPTION
it allows to configure environment variables

i.e.
```
@RegisterExtension
public static PostgreSQL db = ServiceFactory.create(PostgreSQL.class
        , config -> config.addEnvironmentVariable("POSTGRESQL_MAX_PREPARED_TRANSACTIONS", "10"));
```

in the local database I had to move the `DBContainer` instantiation from the constructor to the `deploy()` method in order to call the `defaultConfiguration()` on the service itself