### PR TITLE
[Fhir] - Make server configurable to enable-disable authentication

### DIFF
--- a/system-x/services/fhir/src/main/java/software/tnb/fhir/account/FhirAccount.java
+++ b/system-x/services/fhir/src/main/java/software/tnb/fhir/account/FhirAccount.java
@@ -1,0 +1,24 @@
+package software.tnb.fhir.account;
+
+import software.tnb.common.account.Account;
+
+public class FhirAccount implements Account {
+    private String username = "admin";
+    private String password = "Admin123";
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public String username() {
+        return username;
+    }
+
+    public String password() {
+        return password;
+    }
+}

--- a/system-x/services/fhir/src/main/java/software/tnb/fhir/resource/local/FhirContainer.java
+++ b/system-x/services/fhir/src/main/java/software/tnb/fhir/resource/local/FhirContainer.java
@@ -12,6 +12,6 @@ public class FhirContainer extends GenericContainer<FhirContainer> {
         super(image);
         withExposedPorts(port);
         withEnv(env);
-        waitingFor(Wait.forHttp("/fhir/metadata").withStartupTimeout(Duration.ofSeconds(240)));
+        waitingFor(Wait.forLogMessage(".*Started.*hapi-fhir-jpaserver.*", 1).withStartupTimeout(Duration.ofSeconds(240)));
     }
 }

--- a/system-x/services/fhir/src/main/java/software/tnb/fhir/resource/local/LocalFhir.java
+++ b/system-x/services/fhir/src/main/java/software/tnb/fhir/resource/local/LocalFhir.java
@@ -36,7 +36,7 @@ public class LocalFhir extends Fhir implements Deployable {
 
     @Override
     public String getServerUrl() {
-        return String.format("http://%s:%d/fhir", container.getHost(), getPortMapping());
+        return String.format("http://%s:%d/hapi-fhir-jpaserver-example/", container.getHost(), getPortMapping());
     }
 
     @Override

--- a/system-x/services/fhir/src/main/java/software/tnb/fhir/service/Fhir.java
+++ b/system-x/services/fhir/src/main/java/software/tnb/fhir/service/Fhir.java
@@ -1,15 +1,15 @@
 package software.tnb.fhir.service;
 
-import software.tnb.common.account.NoAccount;
 import software.tnb.common.client.NoClient;
 import software.tnb.common.deployment.WithDockerImage;
 import software.tnb.common.service.ConfigurableService;
 import software.tnb.common.validation.NoValidation;
+import software.tnb.fhir.account.FhirAccount;
 import software.tnb.fhir.service.configuration.FhirConfiguration;
 
 import java.util.Map;
 
-public abstract class Fhir extends ConfigurableService<NoAccount, NoClient, NoValidation, FhirConfiguration> implements WithDockerImage {
+public abstract class Fhir extends ConfigurableService<FhirAccount, NoClient, NoValidation, FhirConfiguration> implements WithDockerImage {
     public static final int PORT = 8080;
 
     public abstract int getPortMapping();
@@ -19,16 +19,19 @@ public abstract class Fhir extends ConfigurableService<NoAccount, NoClient, NoVa
     public Map<String, String> containerEnvironment() {
         return Map.of(
             "hapi.fhir.fhir_version", getConfiguration().fhirVersion(),
-            "hapi.fhir.reuse_cached_search_results_millis", "-1");
+            "DISABLE_AUTH", Boolean.toString(getConfiguration().getFhirAuthDisabled()),
+            "FHIR_USER", account().username(),
+            "FHIR_PWD", account().password());
     }
 
     @Override
     public String defaultImage() {
-        return "quay.io/fuse_qe/hapi:v7.2.0";
+        return "quay.io/fuse_qe/hapi-fhir-auth:v3.0.1";
     }
 
     @Override
     protected void defaultConfiguration() {
         getConfiguration().withFhirVersion("R4");
+        getConfiguration().withFhirAuthDisabled(true);
     }
 }

--- a/system-x/services/fhir/src/main/java/software/tnb/fhir/service/configuration/FhirConfiguration.java
+++ b/system-x/services/fhir/src/main/java/software/tnb/fhir/service/configuration/FhirConfiguration.java
@@ -6,13 +6,23 @@ public class FhirConfiguration extends ServiceConfiguration {
 
     //supported versions https://github.com/hapifhir/hapi-fhir/blob/master/hapi-fhir-base/src/main/java/ca/uhn/fhir/context/FhirVersionEnum.java
     private static final String FHIR_VERSION = "fhir.version";
+    private static final String FHIR_AUTH_DISABLED = "DISABLE_AUTH";
 
     public FhirConfiguration withFhirVersion(String fhirVersion) {
         set(FHIR_VERSION, fhirVersion);
         return this;
     }
 
+    public FhirConfiguration withFhirAuthDisabled(boolean fhirAuthDisabled) {
+        set(FHIR_AUTH_DISABLED, fhirAuthDisabled);
+        return this;
+    }
+
     public String fhirVersion() {
         return get(FHIR_VERSION, String.class);
+    }
+
+    public boolean getFhirAuthDisabled() {
+        return get(FHIR_AUTH_DISABLED, Boolean.class);
     }
 }


### PR DESCRIPTION
Customer examples require FHIR with basic authentication, at least.
Hapi-Fhir was added to RH dockerfiles repository, including AUTH enabling/disabling