### PR TITLE
otel: new trace stack

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -396,6 +396,11 @@
             </dependency>
             <dependency>
                 <groupId>software.tnb</groupId>
+                <artifactId>system-x-observability</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>software.tnb</groupId>
                 <artifactId>system-x-opensearch</artifactId>
                 <version>1.0-SNAPSHOT</version>
             </dependency>
@@ -492,6 +497,11 @@
             <dependency>
                 <groupId>software.tnb</groupId>
                 <artifactId>system-x-telegram</artifactId>
+                <version>1.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>software.tnb</groupId>
+                <artifactId>system-x-tempo</artifactId>
                 <version>1.0-SNAPSHOT</version>
             </dependency>
             <dependency>

--- a/system-x/services/all/pom.xml
+++ b/system-x/services/all/pom.xml
@@ -287,6 +287,10 @@
         </dependency>
         <dependency>
             <groupId>software.tnb</groupId>
+            <artifactId>system-x-observability</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.tnb</groupId>
             <artifactId>system-x-opensearch</artifactId>
         </dependency>
         <dependency>
@@ -352,6 +356,10 @@
         <dependency>
             <groupId>software.tnb</groupId>
             <artifactId>system-x-telegram</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>software.tnb</groupId>
+            <artifactId>system-x-tempo</artifactId>
         </dependency>
         <dependency>
             <groupId>software.tnb</groupId>

--- a/system-x/services/observability/pom.xml
+++ b/system-x/services/observability/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>system-x-services</artifactId>
+        <groupId>software.tnb</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>system-x-observability</artifactId>
+    <name>TNB :: System-X :: Services :: Observability</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/system-x/services/observability/src/main/java/software/tnb/observability/resource/openshift/OpenshiftObservability.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/resource/openshift/OpenshiftObservability.java
@@ -1,0 +1,143 @@
+package software.tnb.observability.resource.openshift;
+
+import software.tnb.common.deployment.OpenshiftDeployable;
+import software.tnb.common.deployment.WithOperatorHub;
+import software.tnb.common.openshift.OpenshiftClient;
+import software.tnb.common.utils.WaitUtils;
+import software.tnb.observability.service.Observability;
+import software.tnb.observability.validation.ObservabilityValidation;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.auto.service.AutoService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+
+@AutoService(Observability.class)
+public class OpenshiftObservability extends Observability implements OpenshiftDeployable, WithOperatorHub {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenshiftObservability.class);
+
+    @Override
+    public ObservabilityValidation validation() {
+        validation = Optional.ofNullable(validation)
+            .orElseGet(() -> new ObservabilityValidation(getConfiguration().getTempoStackName()));
+        return validation;
+    }
+
+    @Override
+    public void undeploy() {
+        //cluster wide operator can be in use
+    }
+
+    @Override
+    public void openResources() {
+        if (getConfiguration().isDeployTracesUiPlugin()) {
+            //check if the traces endpoint is reachable
+            WaitUtils.waitFor(() -> validation().isTraceEndpointAvailable(), 10, 10000
+                , "Wait until the trace endpoint is available on the OCP console");
+        }
+    }
+
+    @Override
+    public String targetNamespace() {
+        return "openshift-cluster-observability-operator";
+    }
+
+    @Override
+    public void closeResources() {
+
+    }
+
+    @Override
+    public String subscriptionName() {
+        return operatorName();
+    }
+
+    @Override
+    public void create() {
+        LOG.debug("Creating cluster observability subscription");
+        //create target namespace if not exists
+        OpenshiftClient.get().createNamespace(targetNamespace());
+
+        // Create subscription if needed
+        createSubscription();
+
+        createAccordingToConfiguration();
+    }
+
+    private void createAccordingToConfiguration() {
+        if (getConfiguration().isDeployTracesUiPlugin()) {
+            LOG.debug("creating tracing UIPlugin");
+            final String apiVersion = "observability.openshift.io/v1alpha1";
+            final String kind = "UIPlugin";
+            final GenericKubernetesResource cr = new GenericKubernetesResourceBuilder()
+                .withKind(kind)
+                .withApiVersion(apiVersion)
+                .withNewMetadata()
+                .withName("distributed-tracing")
+                .endMetadata()
+                .withAdditionalProperties(Map.of("spec", Map.of("type", "DistributedTracing"))).build();
+            OpenshiftClient.get().genericKubernetesResources(apiVersion, kind).resource(cr).create();
+        }
+    }
+
+    @Override
+    public boolean isDeployed() {
+
+        if (OpenshiftClient.get().operatorHub().subscriptions().inNamespace(targetNamespace()).withName(subscriptionName()).get() == null) {
+            return false;
+        }
+
+        boolean operatorReady = OpenshiftClient.get().arePodsWithLabelReady(targetNamespace()
+            , "app.kubernetes.io/name", "observability-operator");
+        //check pods according to configuration
+        boolean traceUIPluginReady = true;
+        if (getConfiguration().isDeployTracesUiPlugin()) {
+            traceUIPluginReady = OpenshiftClient.get().arePodsWithLabelReady(targetNamespace()
+                , "app.kubernetes.io/instance", "distributed-tracing");
+
+        }
+
+        return operatorReady && traceUIPluginReady;
+    }
+
+    @Override
+    public Predicate<Pod> podSelector() {
+        return p -> OpenshiftClient.get().hasLabels(p, Map.of("app.kubernetes.io/managed-by", "observability-operator"));
+    }
+
+    @Override
+    public List<PodResource> servicePods() {
+        try {
+            return OpenshiftClient.get().inNamespace(targetNamespace()).pods().list().getItems().stream()
+                .filter(podSelector())
+                .map(p -> OpenshiftClient.get().pods().inNamespace(targetNamespace()).withName(p.getMetadata().getName()))
+                .collect(Collectors.toList());
+        } catch (KubernetesClientException kce) {
+            // Just in case of some transient error
+            return null;
+        }
+    }
+
+    @Override
+    public boolean clusterWide() {
+        return true;
+    }
+
+    @Override
+    public String operatorName() {
+        return "cluster-observability-operator";
+    }
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/service/Observability.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/service/Observability.java
@@ -1,0 +1,16 @@
+package software.tnb.observability.service;
+
+import software.tnb.common.account.NoAccount;
+import software.tnb.common.client.NoClient;
+import software.tnb.common.service.ConfigurableService;
+import software.tnb.observability.service.configuration.ObservabilityConfiguration;
+import software.tnb.observability.validation.ObservabilityValidation;
+
+public abstract class Observability extends ConfigurableService<NoAccount, NoClient, ObservabilityValidation, ObservabilityConfiguration> {
+
+    @Override
+    protected void defaultConfiguration() {
+        getConfiguration().withDeployTracesUiPlugin(true)
+            .withTempoStackName("tnb-tempostack");
+    }
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/service/configuration/ObservabilityConfiguration.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/service/configuration/ObservabilityConfiguration.java
@@ -1,0 +1,28 @@
+package software.tnb.observability.service.configuration;
+
+import software.tnb.common.service.configuration.ServiceConfiguration;
+
+public class ObservabilityConfiguration extends ServiceConfiguration {
+
+    private static final String DEPLOY_TRACES_UI_PLUGIN = "observability.plugin.traces.deploy";
+    private static final String TEMPOSTACK_NAME = "observability.tempo.stack.name";
+
+    public Boolean isDeployTracesUiPlugin() {
+        return get(DEPLOY_TRACES_UI_PLUGIN, Boolean.class);
+    }
+
+    public ObservabilityConfiguration withDeployTracesUiPlugin(Boolean deployTracesUiPlugin) {
+        set(DEPLOY_TRACES_UI_PLUGIN, deployTracesUiPlugin);
+        return this;
+    }
+
+    public String getTempoStackName() {
+        return get(TEMPOSTACK_NAME, String.class);
+    }
+
+    public ObservabilityConfiguration withTempoStackName(String tempoStackName) {
+        set(TEMPOSTACK_NAME, tempoStackName);
+        return this;
+    }
+
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/validation/ObservabilityValidation.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/validation/ObservabilityValidation.java
@@ -1,0 +1,146 @@
+package software.tnb.observability.validation;
+
+import software.tnb.common.openshift.OpenshiftClient;
+import software.tnb.common.validation.Validation;
+import software.tnb.observability.validation.model.Span;
+import software.tnb.observability.validation.model.Trace;
+
+import org.junit.jupiter.api.Assertions;
+
+import org.awaitility.Awaitility;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import io.fabric8.kubernetes.client.http.HttpClient;
+import io.fabric8.kubernetes.client.http.HttpRequest;
+import io.fabric8.kubernetes.client.http.HttpResponse;
+
+public class ObservabilityValidation implements Validation {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ObservabilityValidation.class);
+
+    private final HttpClient client;
+    private final String baseUrl;
+    private final ObjectMapper objectMapper;
+
+    public ObservabilityValidation(String tempoStackName) {
+        this.client = OpenshiftClient.get().authorization().getHttpClient();
+        this.baseUrl = "%s/api/proxy/plugin/distributed-tracing-console-plugin/backend/proxy/%s/%s/application/api"
+            .formatted(OpenshiftClient.get().getConsoleUrl(), OpenshiftClient.get().getNamespace(), tempoStackName);
+        this.objectMapper = new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    public boolean isTraceEndpointAvailable() {
+        try {
+            return getResponseFromMenuPage().isSuccessful();
+        } catch (Exception e) {
+            LOG.warn("ignored exception during connectivity test: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Returns the map with spanId as key and @{@link software.tnb.observability.validation.model.Span} as value
+     * @param traceId String, the trace id
+     * @return Map
+     */
+    public Map<String, Span> getFullTrace(String traceId) {
+        try {
+            final Map<String, Span> fullTrace = new HashMap<>();
+            final HttpResponse<String> resp = callWithRetry(new URL("%s/traces/%s".formatted(baseUrl, traceId)), getResponseFromMenuPage());
+            final Trace trace = objectMapper.readValue(resp.body(), Trace.class);
+            trace.getBatches().forEach(batch -> batch.getScopeSpans().forEach(scopeSpan -> scopeSpan.getSpans()
+                .forEach(span -> fullTrace.put(span.getSpanId(), span))));
+            return fullTrace;
+        } catch (JsonProcessingException | MalformedURLException e) {
+            throw new RuntimeException("unable to read json from response", e);
+        }
+    }
+
+    public List<Span> getSpans(String traceId) {
+        return getFullTrace(traceId).values().stream().toList();
+    }
+
+    public List<String> getTraces(String serviceName) {
+        final List<String> traces = new ArrayList<>();
+
+        AtomicReference<Map> result = new AtomicReference<>();
+        Awaitility.await("await for trace to be elaborated")
+            .atMost(30, TimeUnit.SECONDS)
+            .pollInterval(2, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                final HttpResponse<String> resp = callWithRetry(new URL(baseUrl + "/search?q="
+                        + URLEncoder.encode("{ resource.service.name = \"" + serviceName + "\" }", StandardCharsets.UTF_8))
+                    , getResponseFromMenuPage());
+                result.set(objectMapper.readValue(resp.body(), Map.class));
+                Assertions.assertFalse(((List<?>) result.get().get("traces")).isEmpty());
+            });
+
+        ((List<Map<String, Object>>) result.get().get("traces")).forEach(trace -> traces.add((String) trace.get("traceID")));
+
+        return traces;
+    }
+
+    private HttpResponse<String> callWithRetry(URL url, HttpResponse<String> landingPage) {
+        final Map<String, String> secHeaders = getSecurityHeaders(landingPage);
+        final HttpRequest.Builder proxyReqBuilder = client.newHttpRequestBuilder()
+            .url(url);
+        proxyReqBuilder.header("Cookie", String.join("; ", secHeaders.entrySet().stream()
+            .map(e -> e.getKey() + "=" + e.getValue())
+            .toList()));
+        final HttpRequest proxyReq = proxyReqBuilder.build();
+        final AtomicReference<HttpResponse<String>> resp = new AtomicReference<>();
+        Awaitility.await("wait for response on " + url).atMost(30, TimeUnit.SECONDS)
+            .untilAsserted(() -> {
+                resp.set(client.sendAsync(proxyReq, String.class).get());
+                Assertions.assertTrue(resp.get().isSuccessful(), "Check response code " + url + " : " + resp.get().code());
+            });
+        return resp.get();
+    }
+
+    private HttpResponse<String> getResponseFromMenuPage() {
+        final HttpRequest proxyReq;
+        try {
+            proxyReq = client.newHttpRequestBuilder()
+                    .url(new URL("%s/observe/traces".formatted(OpenshiftClient.get().getConsoleUrl()))).build();
+            return client.sendAsync(proxyReq, String.class).get();
+        } catch (MalformedURLException | ExecutionException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, String> getSecurityHeaders(HttpResponse<String> response) {
+        final Map<String, String> headers = new HashMap<>();
+        headers.put("openshift-session-token", OpenshiftClient.get().getOauthToken());
+        final List<String> setCookie = response.headers("set-cookie");
+        if (setCookie != null) {
+            setCookie.forEach(header -> headers.putAll(Arrays.stream(header.split(";"))
+                    .map(String::trim)
+                    .filter(h -> !h.toLowerCase().startsWith("path"))
+                    .filter(h -> !h.toLowerCase().startsWith("httponly"))
+                    .filter(h -> !h.toLowerCase().startsWith("secure"))
+                    .filter(h -> !h.toLowerCase().startsWith("samesite"))
+                    .map(h -> h.split("="))
+                    .collect(Collectors.toMap(strings -> strings[0], strings -> strings[1]))));
+        }
+        return headers;
+    }
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/ArrayValue.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/ArrayValue.java
@@ -1,0 +1,19 @@
+package software.tnb.observability.validation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+
+public class ArrayValue {
+
+    ArrayList<Value> values;
+
+    @JsonProperty("values")
+    public ArrayList<Value> getValues() {
+        return this.values;
+    }
+
+    public void setValues(ArrayList<Value> values) {
+        this.values = values;
+    }
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Attribute.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Attribute.java
@@ -1,0 +1,26 @@
+package software.tnb.observability.validation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Attribute {
+    String key;
+    Value value;
+
+    @JsonProperty("key")
+    public String getKey() {
+        return this.key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    @JsonProperty("value")
+    public Value getValue() {
+        return this.value;
+    }
+
+    public void setValue(Value value) {
+        this.value = value;
+    }
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Batch.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Batch.java
@@ -1,0 +1,28 @@
+package software.tnb.observability.validation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+
+public class Batch {
+    Resource resource;
+    ArrayList<ScopeSpan> scopeSpans;
+
+    @JsonProperty("resource")
+    public Resource getResource() {
+        return this.resource;
+    }
+
+    public void setResource(Resource resource) {
+        this.resource = resource;
+    }
+
+    @JsonProperty("scopeSpans")
+    public ArrayList<ScopeSpan> getScopeSpans() {
+        return this.scopeSpans;
+    }
+
+    public void setScopeSpans(ArrayList<ScopeSpan> scopeSpans) {
+        this.scopeSpans = scopeSpans;
+    }
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Event.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Event.java
@@ -1,0 +1,38 @@
+package software.tnb.observability.validation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+
+public class Event {
+    String timeUnixNano;
+    String name;
+    ArrayList<Attribute> attributes;
+
+    @JsonProperty("timeUnixNano")
+    public String getTimeUnixNano() {
+        return this.timeUnixNano;
+    }
+
+    public void setTimeUnixNano(String timeUnixNano) {
+        this.timeUnixNano = timeUnixNano;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("attributes")
+    public ArrayList<Attribute> getAttributes() {
+        return this.attributes;
+    }
+
+    public void setAttributes(ArrayList<Attribute> attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Resource.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Resource.java
@@ -1,0 +1,18 @@
+package software.tnb.observability.validation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+
+public class Resource {
+    ArrayList<Attribute> attributes;
+
+    @JsonProperty("attributes")
+    public ArrayList<Attribute> getAttributes() {
+        return this.attributes;
+    }
+
+    public void setAttributes(ArrayList<Attribute> attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Scope.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Scope.java
@@ -1,0 +1,16 @@
+package software.tnb.observability.validation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Scope {
+    String name;
+
+    @JsonProperty("name")
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/ScopeSpan.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/ScopeSpan.java
@@ -1,0 +1,28 @@
+package software.tnb.observability.validation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+
+public class ScopeSpan {
+    Scope scope;
+    ArrayList<Span> spans;
+
+    @JsonProperty("scope")
+    public Scope getScope() {
+        return this.scope;
+    }
+
+    public void setScope(Scope scope) {
+        this.scope = scope;
+    }
+
+    @JsonProperty("spans")
+    public ArrayList<Span> getSpans() {
+        return this.spans;
+    }
+
+    public void setSpans(ArrayList<Span> spans) {
+        this.spans = spans;
+    }
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Span.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Span.java
@@ -1,0 +1,118 @@
+package software.tnb.observability.validation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+
+public class Span {
+    String traceId;
+    String spanId;
+    String parentSpanId;
+    int flags;
+    String name;
+    String kind;
+    String startTimeUnixNano;
+    String endTimeUnixNano;
+    ArrayList<Attribute> attributes;
+    ArrayList<Event> events;
+    Status status;
+
+    @JsonProperty("traceId")
+    public String getTraceId() {
+        return this.traceId;
+    }
+
+    public void setTraceId(String traceId) {
+        this.traceId = traceId;
+    }
+
+    @JsonProperty("spanId")
+    public String getSpanId() {
+        return this.spanId;
+    }
+
+    public void setSpanId(String spanId) {
+        this.spanId = spanId;
+    }
+
+    @JsonProperty("parentSpanId")
+    public String getParentSpanId() {
+        return this.parentSpanId;
+    }
+
+    public void setParentSpanId(String parentSpanId) {
+        this.parentSpanId = parentSpanId;
+    }
+
+    @JsonProperty("flags")
+    public int getFlags() {
+        return this.flags;
+    }
+
+    public void setFlags(int flags) {
+        this.flags = flags;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("kind")
+    public String getKind() {
+        return this.kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    @JsonProperty("startTimeUnixNano")
+    public String getStartTimeUnixNano() {
+        return this.startTimeUnixNano;
+    }
+
+    public void setStartTimeUnixNano(String startTimeUnixNano) {
+        this.startTimeUnixNano = startTimeUnixNano;
+    }
+
+    @JsonProperty("endTimeUnixNano")
+    public String getEndTimeUnixNano() {
+        return this.endTimeUnixNano;
+    }
+
+    public void setEndTimeUnixNano(String endTimeUnixNano) {
+        this.endTimeUnixNano = endTimeUnixNano;
+    }
+
+    @JsonProperty("attributes")
+    public ArrayList<Attribute> getAttributes() {
+        return this.attributes;
+    }
+
+    public void setAttributes(ArrayList<Attribute> attributes) {
+        this.attributes = attributes;
+    }
+
+    @JsonProperty("events")
+    public ArrayList<Event> getEvents() {
+        return this.events;
+    }
+
+    public void setEvents(ArrayList<Event> events) {
+        this.events = events;
+    }
+
+    @JsonProperty("status")
+    public Status getStatus() {
+        return this.status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Status.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Status.java
@@ -1,0 +1,4 @@
+package software.tnb.observability.validation.model;
+
+public class Status {
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Trace.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Trace.java
@@ -1,0 +1,18 @@
+package software.tnb.observability.validation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+
+public class Trace {
+    ArrayList<Batch> batches;
+
+    @JsonProperty("batches")
+    public ArrayList<Batch> getBatches() {
+        return this.batches;
+    }
+
+    public void setBatches(ArrayList<Batch> batches) {
+        this.batches = batches;
+    }
+}

--- a/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Value.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/validation/model/Value.java
@@ -1,0 +1,36 @@
+package software.tnb.observability.validation.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Value {
+    String stringValue;
+    ArrayValue arrayValue;
+    String intValue;
+
+    @JsonProperty("stringValue")
+    public String getStringValue() {
+        return this.stringValue;
+    }
+
+    public void setStringValue(String stringValue) {
+        this.stringValue = stringValue;
+    }
+
+    @JsonProperty("arrayValue")
+    public ArrayValue getArrayValue() {
+        return this.arrayValue;
+    }
+
+    public void setArrayValue(ArrayValue arrayValue) {
+        this.arrayValue = arrayValue;
+    }
+
+    @JsonProperty("intValue")
+    public String getIntValue() {
+        return this.intValue;
+    }
+
+    public void setIntValue(String intValue) {
+        this.intValue = intValue;
+    }
+}

--- a/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/resource/openshift/OpenshiftOpenTelemetryCollector.java
+++ b/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/resource/openshift/OpenshiftOpenTelemetryCollector.java
@@ -4,6 +4,8 @@ import software.tnb.common.deployment.OpenshiftDeployable;
 import software.tnb.common.deployment.WithCustomResource;
 import software.tnb.common.deployment.WithOperatorHub;
 import software.tnb.common.openshift.OpenshiftClient;
+import software.tnb.common.utils.StringUtils;
+import software.tnb.common.utils.WaitUtils;
 import software.tnb.opentelemetry.service.OpenTelemetryCollector;
 
 import org.slf4j.Logger;
@@ -11,23 +13,39 @@ import org.slf4j.LoggerFactory;
 
 import com.google.auto.service.AutoService;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBindingBuilder;
+import io.fabric8.kubernetes.api.model.rbac.RoleRef;
+import io.fabric8.kubernetes.api.model.rbac.Subject;
 
 @AutoService(OpenTelemetryCollector.class)
 public class OpenshiftOpenTelemetryCollector extends OpenTelemetryCollector implements OpenshiftDeployable, WithOperatorHub, WithCustomResource {
 
     private static final Logger LOG = LoggerFactory.getLogger(OpenshiftOpenTelemetryCollector.class);
     private static final String OTEL_INSTANCE_NAME = "otel-tnb";
+    private final String saName = "otel-collector";
+    private final String roleBindingName = "tempostack-traces-" + StringUtils.getRandomAlphanumStringOfLength(4);
 
     @Override
     public void undeploy() {
-        //cluster wide operator can be in use
+
+        OpenshiftClient.get().deleteCustomResource(apiVersion().split("/")[0], apiVersion().split("/")[1], kind(), OTEL_INSTANCE_NAME);
+        WaitUtils.waitFor(() -> servicePods().isEmpty(), "wait until collector pods are terminated");
+
+        if (getConfiguration().isTempostack()) {
+            //remove the cluster role binding
+            OpenshiftClient.get().rbac().clusterRoleBindings().withName(roleBindingName).delete();
+            //remove service account
+            OpenshiftClient.get().deleteServiceAccount(saName);
+        }
     }
 
     @Override
@@ -54,7 +72,33 @@ public class OpenshiftOpenTelemetryCollector extends OpenTelemetryCollector impl
         // Create subscription if needed
         createSubscription();
 
+        if (getConfiguration().isTempostack()) {
+            // create serviceAccount
+            createAndConfigureSA();
+        }
+
         OpenshiftClient.get().genericKubernetesResources(apiVersion(), kind()).resource(customResource()).create();
+    }
+
+    private void createAndConfigureSA() {
+        OpenshiftClient.get().createServiceAccount(saName);
+
+        List<Subject> subjects = new ArrayList<>();
+        Subject subject = new Subject();
+        subject.setKind("ServiceAccount");
+        subject.setName(saName);
+        subject.setNamespace(OpenshiftClient.get().getNamespace());
+        subjects.add(subject);
+        RoleRef roleRef = new RoleRef();
+        roleRef.setApiGroup("rbac.authorization.k8s.io");
+        roleRef.setKind("ClusterRole");
+        roleRef.setName("tempostack-traces-write"); //created in tempostack
+        OpenshiftClient.get().rbac().clusterRoleBindings().resource(new ClusterRoleBindingBuilder()
+                .withNewMetadata().withName(roleBindingName).endMetadata()
+                .withRoleRef(roleRef)
+                .addAllToSubjects(subjects)
+                .build())
+            .serverSideApply();
     }
 
     @Override
@@ -117,6 +161,9 @@ public class OpenshiftOpenTelemetryCollector extends OpenTelemetryCollector impl
             spec.put("ports", getConfiguration().getPorts());
         }
         spec.put("replicas", getConfiguration().getReplicas());
+        if (getConfiguration().isTempostack()) {
+            spec.put("serviceAccount", saName);
+        }
 
         return new GenericKubernetesResourceBuilder()
             .withKind(kind())

--- a/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/service/OpenTelemetryCollector.java
+++ b/system-x/services/opentelemetry/src/main/java/software/tnb/opentelemetry/service/OpenTelemetryCollector.java
@@ -16,6 +16,12 @@ public abstract class OpenTelemetryCollector extends ConfigurableService<NoAccou
 
     @Override
     protected void defaultConfiguration() {
-        getConfiguration().withReplicas(1).withActuatorHealthCheckExcluded();
+        getConfiguration().withDefaultReceivers()
+            .withDefaultProcessors()
+            .withDefaultExporters()
+            .withDefaultServices()
+            .withReplicas(1)
+            .withActuatorHealthCheckExcluded()
+            .useTempostack(false);
     }
 }

--- a/system-x/services/pom.xml
+++ b/system-x/services/pom.xml
@@ -62,6 +62,8 @@
         <module>ssh</module>
         <module>hawtio</module>
         <module>keycloak</module>
+        <module>tempo</module>
+        <module>observability</module>
         <!-- keep the "all" module last as it needs to collect all previous modules -->
         <module>all</module>
     </modules>

--- a/system-x/services/tempo/pom.xml
+++ b/system-x/services/tempo/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>system-x-services</artifactId>
+        <groupId>software.tnb</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>system-x-tempo</artifactId>
+    <name>TNB :: System-X :: Services :: Tempo</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>software.tnb</groupId>
+            <artifactId>system-x-aws-s3</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/system-x/services/tempo/src/main/java/software/tnb/tempo/resource/openshift/OpenshiftTempo.java
+++ b/system-x/services/tempo/src/main/java/software/tnb/tempo/resource/openshift/OpenshiftTempo.java
@@ -1,0 +1,205 @@
+package software.tnb.tempo.resource.openshift;
+
+import software.tnb.aws.s3.service.Minio;
+import software.tnb.common.deployment.OpenshiftDeployable;
+import software.tnb.common.deployment.WithCustomResource;
+import software.tnb.common.deployment.WithOperatorHub;
+import software.tnb.common.openshift.OpenshiftClient;
+import software.tnb.common.service.ServiceFactory;
+import software.tnb.common.utils.WaitUtils;
+import software.tnb.tempo.service.Tempo;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.auto.service.AutoService;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
+import io.fabric8.kubernetes.api.model.GenericKubernetesResourceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+
+@AutoService(Tempo.class)
+public class OpenshiftTempo extends Tempo implements OpenshiftDeployable, WithOperatorHub, WithCustomResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OpenshiftTempo.class);
+    private static final String INSTANCE_NAME = "tnb-tempostack";
+    private static final String MINIO_SECRET_TEMPOSTACK = "minio-secret-tempostack";
+    private static final String MINIO_BUCKET = "tempo";
+    private static final String STORAGE_TYPE = "s3";
+    private static final String STORAGE_SIZE = "1Gi";
+
+    private final Minio minio = ServiceFactory.create(Minio.class);
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        minio.beforeAll(context);
+        OpenshiftDeployable.super.beforeAll(context);
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) throws Exception {
+        OpenshiftDeployable.super.afterAll(context);
+        minio.afterAll(context);
+    }
+
+    @Override
+    public void undeploy() {
+        OpenshiftClient.get().deleteCustomResource(apiVersion().split("/")[0], apiVersion().split("/")[1], kind(), INSTANCE_NAME);
+        WaitUtils.waitFor(() -> servicePods().isEmpty(), "wait until tempostack pods are terminated");
+    }
+
+    @Override
+    public void openResources() {
+    }
+
+    @Override
+    public String targetNamespace() {
+        return "openshift-tempo-operator";
+    }
+
+    @Override
+    public void closeResources() {
+
+    }
+
+    @Override
+    public void create() {
+        LOG.debug("Creating Tempo subscription");
+        //create target namespace if not exists
+        OpenshiftClient.get().createNamespace(targetNamespace());
+
+        // Create subscription if needed
+        createSubscription();
+
+        // Create Roles to allow the traces to be read/written
+        createRoles();
+
+        //create minio storage
+        createMinioStorage();
+
+        //create stack in the current namespace
+        OpenshiftClient.get().genericKubernetesResources(apiVersion(), kind())
+            .inNamespace(OpenshiftClient.get().getNamespace())
+            .resource(customResource()).create();
+    }
+
+    private void createRoles() {
+        OpenshiftClient.get().serverSideApply("/software/tnb/tempo/resource/openshift/00-CR-tracereader.yaml");
+        OpenshiftClient.get().serverSideApply("/software/tnb/tempo/resource/openshift/01-CRB-tracereader.yaml");
+        OpenshiftClient.get().serverSideApply("/software/tnb/tempo/resource/openshift/02-CR-tracewriter.yaml");
+    }
+
+    @Override
+    public boolean isDeployed() {
+        return OpenshiftClient.get().apps().deployments()
+            .inNamespace(targetNamespace()).list().getItems().stream()
+            .anyMatch(deployment -> INSTANCE_NAME.equals(deployment.getMetadata().getName()));
+    }
+
+    @Override
+    public Predicate<Pod> podSelector() {
+        return p -> OpenshiftClient.get().hasLabels(p, Map.of("app.kubernetes.io/managed-by", "tempo-operator"));
+    }
+
+    @Override
+    public boolean clusterWide() {
+        return true;
+    }
+
+    @Override
+    public String operatorName() {
+        return "tempo-product";
+    }
+
+    @Override
+    public String getLog() {
+        return OpenshiftClient.get().getPodLog(servicePod().get());
+    }
+
+    @Override
+    public String getDistributorHostname() {
+        return "tempo-%s-distributor".formatted(INSTANCE_NAME);
+    }
+
+    @Override
+    public String getGatewayHostname() {
+        return "tempo-%s-gateway".formatted(INSTANCE_NAME);
+    }
+
+    @Override
+    public String getGatewayUrl() {
+        return "%s:8090".formatted(getGatewayHostname());
+    }
+
+    @Override
+    public String kind() {
+        return "TempoStack";
+    }
+
+    @Override
+    public String apiVersion() {
+        return "tempo.grafana.com/v1alpha1";
+    }
+
+    @Override
+    public GenericKubernetesResource customResource() {
+
+        Map<String, Object> spec = new HashMap<>();
+        Map<String, Object> resources = new HashMap<>();
+        Map<String, Object> resourcesTotal = new HashMap<>();
+        resourcesTotal.put("limits", Map.of("cpu", getConfiguration().getResourceLimitsCpu()
+            , "memory", getConfiguration().getResourceLimitsMemory()));
+        resources.put("total", resourcesTotal);
+        spec.put("resources", resources);
+        spec.put("managementState", "Managed");
+        Map<String, Object> storage = new HashMap<>();
+        storage.put("secret", Map.of("type", STORAGE_TYPE
+            , "name", MINIO_SECRET_TEMPOSTACK));
+        spec.put("storage", storage);
+        spec.put("storageSize", STORAGE_SIZE);
+        spec.put("replicationFactor", 1);
+        Map<String, Object> template = new HashMap<>();
+        template.put("gateway", Map.of("enabled", true));
+        spec.put("template", template);
+        Map<String, Object> tenants = new HashMap<>();
+        tenants.put("mode", "openshift");
+        tenants.put("authentication", List.of(Map.of("tenantId", "application", "tenantName", "application")));
+        spec.put("tenants", tenants);
+
+        return new GenericKubernetesResourceBuilder()
+            .withKind(kind())
+            .withApiVersion(apiVersion())
+            .withNewMetadata()
+            .withName(INSTANCE_NAME)
+            .endMetadata()
+            .withAdditionalProperties(Map.of("spec", spec)).build();
+    }
+
+    private void createMinioStorage() {
+        Map<String, String> config = Map.of("access_key_id", minio.account().accessKey()
+            , "access_key_secret", minio.account().secretKey()
+            , "endpoint", minio.hostname()
+            , "bucket", MINIO_BUCKET);
+
+        //create needed bucket
+        minio.validation().createS3Bucket(MINIO_BUCKET);
+        minio.validation().waitForBucket(MINIO_BUCKET);
+
+        Secret storageSecret = new SecretBuilder()
+            .withStringData(config)
+            .withNewMetadata()
+            .withName(MINIO_SECRET_TEMPOSTACK)
+            .endMetadata().build();
+        OpenshiftClient.get().secrets().inNamespace(OpenshiftClient.get().getNamespace())
+            .resource(storageSecret).create();
+    }
+}

--- a/system-x/services/tempo/src/main/java/software/tnb/tempo/service/Tempo.java
+++ b/system-x/services/tempo/src/main/java/software/tnb/tempo/service/Tempo.java
@@ -1,0 +1,25 @@
+package software.tnb.tempo.service;
+
+import software.tnb.common.account.NoAccount;
+import software.tnb.common.client.NoClient;
+import software.tnb.common.service.ConfigurableService;
+import software.tnb.common.validation.NoValidation;
+import software.tnb.tempo.service.configuration.TempoConfiguration;
+
+public abstract class Tempo extends ConfigurableService<NoAccount, NoClient, NoValidation, TempoConfiguration> {
+
+    public abstract String getLog();
+
+    public abstract String getDistributorHostname();
+
+    public abstract String getGatewayHostname();
+
+    public abstract String getGatewayUrl();
+
+    @Override
+    protected void defaultConfiguration() {
+        getConfiguration()
+            .withResourceLimitsCpu("2000m")
+            .withResourceLimitsMemory("2Gi");
+    }
+}

--- a/system-x/services/tempo/src/main/java/software/tnb/tempo/service/configuration/TempoConfiguration.java
+++ b/system-x/services/tempo/src/main/java/software/tnb/tempo/service/configuration/TempoConfiguration.java
@@ -1,0 +1,27 @@
+package software.tnb.tempo.service.configuration;
+
+import software.tnb.common.service.configuration.ServiceConfiguration;
+
+public class TempoConfiguration extends ServiceConfiguration {
+
+    private static final String RESOURCE_LIMITS_CPU = "tempo.resource.limits.cpu";
+    private static final String RESOURCE_LIMITS_MEMORY = "tempo.resource.limits.memory";
+
+    public TempoConfiguration withResourceLimitsCpu(String cpu) {
+        set(RESOURCE_LIMITS_CPU, cpu);
+        return this;
+    }
+
+    public String getResourceLimitsCpu() {
+        return get(RESOURCE_LIMITS_CPU, String.class);
+    }
+
+    public TempoConfiguration withResourceLimitsMemory(String memory) {
+        set(RESOURCE_LIMITS_MEMORY, memory);
+        return this;
+    }
+
+    public String getResourceLimitsMemory() {
+        return get(RESOURCE_LIMITS_MEMORY, String.class);
+    }
+}

--- a/system-x/services/tempo/src/main/resources/software/tnb/tempo/resource/openshift/00-CR-tracereader.yaml
+++ b/system-x/services/tempo/src/main/resources/software/tnb/tempo/resource/openshift/00-CR-tracereader.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tempostack-traces-reader
+rules:
+  - apiGroups:
+      - 'tempo.grafana.com'
+    resources:
+      - application
+    resourceNames:
+      - traces
+    verbs:
+      - 'get'

--- a/system-x/services/tempo/src/main/resources/software/tnb/tempo/resource/openshift/01-CRB-tracereader.yaml
+++ b/system-x/services/tempo/src/main/resources/software/tnb/tempo/resource/openshift/01-CRB-tracereader.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: tempostack-traces-reader
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: tempostack-traces-reader
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:authenticated

--- a/system-x/services/tempo/src/main/resources/software/tnb/tempo/resource/openshift/02-CR-tracewriter.yaml
+++ b/system-x/services/tempo/src/main/resources/software/tnb/tempo/resource/openshift/02-CR-tracewriter.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tempostack-traces-write
+rules:
+  - apiGroups:
+      - 'tempo.grafana.com'
+    resources:
+      - application
+    resourceNames:
+      - traces
+    verbs:
+      - 'create'


### PR DESCRIPTION
since OCP 4.19 the jaeger operator is not more available so it is necessary to implement the distributed tracing according to the new stack (tempo+observabilty operator UI plugin) according to [Tempo installation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/distributed_tracing/distr-tracing-tempo-installing#installing-the-tempo-operator_distr-tracing-tempo-installing)

The current stack uses MinIO and Tempostack with OTEL collector to collect traces, the UI Plugin will show the traces in the OCP console [(doc)](https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/cluster_observability_operator/observability-ui-plugins#distributed-tracing-ui-plugin)

a possible configuration could be

```
    @RegisterExtension
    public static TempoStack tempoStack = ServiceFactory.create(TempoStack.class);

    @RegisterExtension
    public static OpenTelemetryCollector otelCollector = ServiceFactory.create(OpenTelemetryCollector.class
        , conf -> conf.withPrometheusExporter().useTempostack(OpenshiftConfiguration.isOpenshift())
                    .withOtlpTracesExporter(tempoStack.getGatewayUrl()));

    @RegisterExtension
    public static Observability observability = ServiceFactory.create(Observability.class);
```

those extensions use the full trace stack and the UI plugin will be installed in the OCP console that can be query through  the Observability validation, such as `observability.validation().getSpans(traceId)`