### PR TITLE
[IBMMQ] Bump ssl ciphersuite

### DIFF
--- a/system-x/services/jms/amq/src/main/java/software/tnb/jms/amq/resource/local/LocalAMQBroker.java
+++ b/system-x/services/jms/amq/src/main/java/software/tnb/jms/amq/resource/local/LocalAMQBroker.java
@@ -26,7 +26,7 @@ public class LocalAMQBroker extends AMQBroker implements ContainerDeployable<AMQ
 
     @Override
     public String defaultImage() {
-        return "registry.redhat.io/amq7/amq-broker-rhel8:7.12.3";
+        return "registry.redhat.io/amq7/amq-broker-rhel9:7.13.3";
     }
 
     @Override

--- a/system-x/services/jms/amq/src/main/java/software/tnb/jms/amq/resource/openshift/OpenshiftAMQBroker.java
+++ b/system-x/services/jms/amq/src/main/java/software/tnb/jms/amq/resource/openshift/OpenshiftAMQBroker.java
@@ -50,8 +50,8 @@ public class OpenshiftAMQBroker extends AMQBroker implements OpenshiftDeployable
     WithName {
     private static final Logger LOG = LoggerFactory.getLogger(OpenshiftAMQBroker.class);
     private static final String SSL_SECRET_NAME = "tnb-ssl-secret";
-    public static final String OPERATOR_NAME = "amq-broker-rhel8";
-    public static final String OPERATOR_CHANNEL = "7.12.x";
+    public static final String OPERATOR_NAME = "amq-broker-rhel9";
+    public static final String OPERATOR_CHANNEL = "7.13.x";
 
     @Override
     public void create() {

--- a/system-x/services/jms/amq/src/main/java/software/tnb/jms/amq/resource/openshift/deployment/DeploymentAMQBroker.java
+++ b/system-x/services/jms/amq/src/main/java/software/tnb/jms/amq/resource/openshift/deployment/DeploymentAMQBroker.java
@@ -95,7 +95,7 @@ public class DeploymentAMQBroker extends AMQBroker implements MicroshiftDeployab
 
     @Override
     public String defaultImage() {
-        return "registry.redhat.io/amq7/amq-broker-rhel8:7.11.0";
+        return "registry.redhat.io/amq7/amq-broker-rhel9:7.13.3";
     }
 
     @Override

--- a/system-x/services/jms/ibm-mq/pom.xml
+++ b/system-x/services/jms/ibm-mq/pom.xml
@@ -14,7 +14,7 @@
     <name>TNB :: System-X :: Services :: JMS :: IBM-MQ</name>
 
     <properties>
-        <ibm.mq.version>9.4.2.0</ibm.mq.version>
+        <ibm.mq.version>9.4.5.0</ibm.mq.version>
     </properties>
 
     <dependencies>

--- a/system-x/services/jms/ibm-mq/src/main/java/software/tnb/jms/ibm/mq/service/IBMMQ.java
+++ b/system-x/services/jms/ibm-mq/src/main/java/software/tnb/jms/ibm/mq/service/IBMMQ.java
@@ -45,7 +45,7 @@ public abstract class IBMMQ extends ConfigurableService<IBMMQAccount, Connection
 
     // In 9.4 the environment variable for password is deprecated, so for the next bump it will be needed to migrate to docker secrets
     public String defaultImage() {
-        return "icr.io/ibm-messaging/mq:9.4.2.0-r2";
+        return "icr.io/ibm-messaging/mq:9.4.5.0-r1";
     }
 
     /**

--- a/system-x/services/jms/ibm-mq/src/main/java/software/tnb/jms/ibm/mq/service/IBMMQ.java
+++ b/system-x/services/jms/ibm-mq/src/main/java/software/tnb/jms/ibm/mq/service/IBMMQ.java
@@ -26,7 +26,7 @@ public abstract class IBMMQ extends ConfigurableService<IBMMQAccount, Connection
     public static final String KEYS_FOLDER = "/etc/mqm/pki/keys/mykey";
     public static final String SSL_FOLDER = "/mnt/mqm/data/qmgrs/%s/ssl";
     public static final String MQSC_COMMAND_FILE_NAME = "99-tnb.mqsc";
-    public static final String SSLCIPHERSUITE = "TLS_RSA_WITH_AES_128_CBC_SHA256";
+    public static final String SSLCIPHERSUITE = "TLS_AES_128_GCM_SHA256";
 
     public Map<String, String> containerEnvironment() {
         return Map.of(


### PR DESCRIPTION
Bump the ciphersuite as with the old one the test was failing on semeru21 with:

```
SSLHandshakeException: No appropriate protocol (protocol is disabled or cipher suites are inappropriate)
```

also pick commits from #1788 