### PR TITLE
Add JGit SSH transport dependency

### DIFF
--- a/fuse-products/pom.xml
+++ b/fuse-products/pom.xml
@@ -73,6 +73,11 @@
             <version>${jgit.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit.ssh.apache</artifactId>
+            <version>${jgit.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>


### PR DESCRIPTION
## Summary
- Add `org.eclipse.jgit.ssh.apache` dependency to enable SSH transport in JGit, required for cloning repos from `github.ibm.com` via SSH URLs using SSH agent forwarding.
