### PR TITLE
[Milvus] - Copy etcd config file into container

### DIFF
--- a/system-x/services/ai/milvus/src/main/java/software/tnb/milvus/resource/local/MilvusContainer.java
+++ b/system-x/services/ai/milvus/src/main/java/software/tnb/milvus/resource/local/MilvusContainer.java
@@ -1,13 +1,10 @@
 package software.tnb.milvus.resource.local;
 
-import software.tnb.common.utils.IOUtils;
 import software.tnb.milvus.service.Milvus;
 
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
-
-import java.nio.file.Path;
+import org.testcontainers.images.builder.Transferable;
 
 public class MilvusContainer extends GenericContainer<MilvusContainer> {
 
@@ -15,14 +12,8 @@ public class MilvusContainer extends GenericContainer<MilvusContainer> {
         super(image);
         this.withExposedPorts(port);
         Milvus.MILVUS_ENV.forEach(this::withEnv);
-        this.withFileSystemBind(createEtcdConfig(), "/milvus/configs/embedEtcd.yaml", BindMode.READ_ONLY);
+        this.withCopyToContainer(Transferable.of(Milvus.embedEtcdConfig()), "/milvus/configs/embedEtcd.yaml");
         this.withCommand("milvus", "run", "standalone");
         this.waitingFor(Wait.forLogMessage(".*Proxy successfully started.*", 1));
-    }
-
-    private static String createEtcdConfig() {
-        Path configFile = IOUtils.createTempFolderStructure("milvus").resolve("embedEtcd.yaml");
-        IOUtils.writeFile(configFile, Milvus.embedEtcdConfig());
-        return configFile.toAbsolutePath().toString();
     }
 }


### PR DESCRIPTION
This should prevent failure on w2k22. Or whatever we use a remote docker deamon. This fix sends the file content through the Docker API, so it works regardless of where Docker runs