### PR TITLE
Fix Observability UIPlugin not being created when operator already exists

### DIFF
--- a/common/src/main/java/software/tnb/common/openshift/OpenshiftClient.java
+++ b/common/src/main/java/software/tnb/common/openshift/OpenshiftClient.java
@@ -896,8 +896,9 @@ public class OpenshiftClient extends OpenShift {
      * @return boolean, if the pods are found and if the status is ready for all matching pods
      */
     public boolean arePodsWithLabelReady(String namespace, String labelKey, String labelValue) {
-        return OpenshiftClient.get().pods().inNamespace(namespace).withLabel(labelKey, labelValue)
-            .list().getItems().stream()
+        List<Pod> pods = OpenshiftClient.get().pods().inNamespace(namespace).withLabel(labelKey, labelValue)
+            .list().getItems();
+        return !pods.isEmpty() && pods.stream()
             .filter(pod -> pod.getStatus() != null)
             .filter(pod -> pod.getStatus().getConditions() != null)
             .allMatch(pod -> pod.getStatus().getConditions().stream()

--- a/system-x/services/observability/src/main/java/software/tnb/observability/resource/openshift/OpenshiftObservability.java
+++ b/system-x/services/observability/src/main/java/software/tnb/observability/resource/openshift/OpenshiftObservability.java
@@ -92,7 +92,6 @@ public class OpenshiftObservability extends Observability implements OpenshiftDe
         if (getConfiguration().isDeployTracesUiPlugin()) {
             traceUIPluginReady = OpenshiftClient.get().arePodsWithLabelReady(targetNamespace()
                 , "app.kubernetes.io/instance", "distributed-tracing");
-
         }
 
         return operatorReady && traceUIPluginReady;


### PR DESCRIPTION
Fix situation when operator is installed but UIPlugin custom resource is not created.

`arePodsWithLabelReady()` returns true when no pods match the label, because [allMatch()](https://github.com/tnb-software/TNB/blob/28a17e0b2b7fa17be7b2b858c20ff99aa79a72e0/common/src/main/java/software/tnb/common/openshift/OpenshiftClient.java#L903) on an empty stream returns true.