### PR TITLE
Add OpenSSH certificate auth support to Mina SSHD service

### DIFF
--- a/system-x/services/mina/src/main/java/software/tnb/mina/resource/local/LocalMina.java
+++ b/system-x/services/mina/src/main/java/software/tnb/mina/resource/local/LocalMina.java
@@ -44,7 +44,7 @@ public class LocalMina extends Mina implements ContainerDeployable<MinaContainer
 
     @Override
     public void deploy() {
-        container = new MinaContainer(image(), getConfiguration().publicKeyPath());
+        container = new MinaContainer(image(), getConfiguration().publicKeyPath(), getConfiguration().caPublicKeyPath());
         ContainerDeployable.super.deploy();
     }
 }

--- a/system-x/services/mina/src/main/java/software/tnb/mina/resource/local/MinaContainer.java
+++ b/system-x/services/mina/src/main/java/software/tnb/mina/resource/local/MinaContainer.java
@@ -4,20 +4,44 @@ import software.tnb.mina.service.Mina;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.MountableFile;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class MinaContainer extends GenericContainer<MinaContainer> {
 
     private static final String AUTHORIZED_KEYS_PATH = "/home/test/.ssh/authorized_keys";
 
-    public MinaContainer(String image, Path publicKeyPath) {
+    public MinaContainer(String image, Path publicKeyPath, Path caPublicKeyPath) {
         super(image);
         withExposedPorts(Mina.SSHD_LISTENING_PORT);
         waitingFor(Wait.forLogMessage(".*Starting SSHD on port.*", 1));
-        if (publicKeyPath != null) {
+
+        if (caPublicKeyPath != null) {
+            withCopyToContainer(
+                Transferable.of(buildAuthorizedKeysContent(publicKeyPath, caPublicKeyPath).getBytes(StandardCharsets.UTF_8)),
+                AUTHORIZED_KEYS_PATH
+            );
+        } else if (publicKeyPath != null) {
             withCopyFileToContainer(MountableFile.forHostPath(publicKeyPath), AUTHORIZED_KEYS_PATH);
         }
+    }
+
+    private static String buildAuthorizedKeysContent(Path publicKeyPath, Path caPublicKeyPath) {
+        StringBuilder sb = new StringBuilder();
+        try {
+            if (publicKeyPath != null) {
+                sb.append(Files.readString(publicKeyPath).trim()).append("\n");
+            }
+            sb.append("cert-authority ").append(Files.readString(caPublicKeyPath).trim()).append("\n");
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to read SSH key files", e);
+        }
+        return sb.toString();
     }
 }

--- a/system-x/services/mina/src/main/java/software/tnb/mina/service/Mina.java
+++ b/system-x/services/mina/src/main/java/software/tnb/mina/service/Mina.java
@@ -24,7 +24,7 @@ public abstract class Mina extends ConfigurableService<MinaAccount, SSHClient, M
 
     @Override
     public String defaultImage() {
-        return "quay.io/fuse_qe/mina-sshd:2.14.0";
+        return "quay.io/fuse_qe/mina-sshd:2.17.1";
     }
 
     protected abstract String clientHostname();

--- a/system-x/services/mina/src/main/java/software/tnb/mina/service/configuration/MinaConfiguration.java
+++ b/system-x/services/mina/src/main/java/software/tnb/mina/service/configuration/MinaConfiguration.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 public class MinaConfiguration extends ServiceConfiguration {
     private static final String PRIVATE_KEY_PATH = "mina.private-key-path";
     private static final String PUBLIC_KEY_PATH = "mina.public-key-path";
+    private static final String CA_PUBLIC_KEY_PATH = "mina.ca-public-key-path";
 
     public MinaConfiguration withPrivateKeyPath(Path value) {
         set(PRIVATE_KEY_PATH, value.toAbsolutePath().toString());
@@ -27,6 +28,17 @@ public class MinaConfiguration extends ServiceConfiguration {
 
     public Path publicKeyPath() {
         return Optional.ofNullable(get(PUBLIC_KEY_PATH, String.class))
+            .map(Path::of)
+            .orElse(null);
+    }
+
+    public MinaConfiguration withCaPublicKeyPath(Path value) {
+        set(CA_PUBLIC_KEY_PATH, value.toAbsolutePath().toString());
+        return this;
+    }
+
+    public Path caPublicKeyPath() {
+        return Optional.ofNullable(get(CA_PUBLIC_KEY_PATH, String.class))
             .map(Path::of)
             .orElse(null);
     }

--- a/system-x/services/mina/src/main/resources/docker/pom.xml
+++ b/system-x/services/mina/src/main/resources/docker/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <sshd.version>2.14.0</sshd.version>
+        <sshd.version>2.17.1</sshd.version>
         <slf4j.version>2.0.16</slf4j.version>
     </properties>
 


### PR DESCRIPTION
## Summary
- Upgrade Apache Mina SSHD from 2.14.0 to 2.17.1 in Docker server image (adds built-in `cert-authority` support via SSHD-1161)
- Add `caPublicKeyPath` configuration to `MinaConfiguration` for specifying a CA public key
- When CA key is provided, `MinaContainer` builds a combined `authorized_keys` file with `cert-authority` entry, enabling OpenSSH certificate authentication
- Update default Docker image tag to `2.17.1`

## Details

The Mina SSHD server previously only supported password and `authorized_keys` public key authentication. With SSHD 2.17.1, the `AuthorizedKeysAuthenticator` natively handles `cert-authority` entries in `authorized_keys`, allowing the server to accept client certificates signed by a trusted CA — no custom authenticator code needed.

### Files changed
| File | Change |
|---|---|
| `docker/pom.xml` | SSHD 2.14.0 → 2.17.1 |
| `Mina.java` | Default image tag 2.14.0 → 2.17.1 |
| `MinaConfiguration.java` | Added `caPublicKeyPath` config |
| `MinaContainer.java` | Builds combined `authorized_keys` with `cert-authority` prefix when CA key provided |
| `LocalMina.java` | Passes `caPublicKeyPath` to `MinaContainer` |

## Test plan
- [x] Existing keypair auth tests pass (Spring Boot + Quarkus)
- [x] New certificate auth tests pass (Spring Boot + Quarkus)
- [ ] Docker image `quay.io/fuse_qe/mina-sshd:2.17.1` needs to be built and pushed