### PR TITLE
jkube: remove pull credentials to fallback to the global configuration

### DIFF
--- a/fuse-products/src/main/java/software/tnb/product/deploystrategy/impl/JKubeWithExternalRepoStrategy.java
+++ b/fuse-products/src/main/java/software/tnb/product/deploystrategy/impl/JKubeWithExternalRepoStrategy.java
@@ -67,18 +67,12 @@ public class JKubeWithExternalRepoStrategy extends CustomJKubeStrategy {
         Optional.ofNullable(DockerConfiguration.dockerRegistryUsername())
             .filter(StringUtils::isNotBlank)
             .map(String::trim)
-            .ifPresent(v -> {
-                props.put("jkube.docker.push.username", v);
-                props.put("jkube.docker.pull.username", v);
-            });
+            .ifPresent(v -> props.put("jkube.docker.push.username", v));
 
         Optional.ofNullable(DockerConfiguration.dockerRegistryPassword())
             .filter(StringUtils::isNotBlank)
             .map(String::trim)
-            .ifPresent(v -> {
-                props.put("jkube.docker.push.password", v);
-                props.put("jkube.docker.pull.password", v);
-            });
+            .ifPresent(v -> props.put("jkube.docker.push.password", v));
 
         return props;
     }


### PR DESCRIPTION
if the push and pull credentials are not compatible, it may cause issues