### PR TITLE
Add runtime version detection for container-based and SQL services

### DIFF
--- a/system-x/common/src/main/java/software/tnb/common/deployment/ContainerDeployable.java
+++ b/system-x/common/src/main/java/software/tnb/common/deployment/ContainerDeployable.java
@@ -13,10 +13,39 @@ import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Image;
 
 import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 public interface ContainerDeployable<T extends GenericContainer<?>> extends Deployable, WithServiceDefinition {
     Logger LOG = LoggerFactory.getLogger(ContainerDeployable.class);
+    Map<ContainerDeployable<?>, String> VERSION_CACHE = new ConcurrentHashMap<>();
+
+    default String containerServiceVersion() {
+        return null;
+    }
+
+    default String resolveAndCacheServiceVersion() {
+        String cached = VERSION_CACHE.get(this);
+        if (cached != null) {
+            return cached;
+        }
+        String version = WithServiceDefinition.super.serviceVersion();
+        if (version == null || "latest".equals(version)) {
+            String fromContainer = containerServiceVersion();
+            if (fromContainer != null) {
+                VERSION_CACHE.put(this, fromContainer);
+                return fromContainer;
+            }
+        }
+        return version;
+    }
+
+    @Override
+    default String serviceVersion() {
+        String cached = VERSION_CACHE.get(this);
+        return cached != null ? cached : WithServiceDefinition.super.serviceVersion();
+    }
 
     T container();
 
@@ -29,6 +58,7 @@ public interface ContainerDeployable<T extends GenericContainer<?>> extends Depl
             throw e;
         }
         LOG.info("{} container started", serviceName());
+        resolveAndCacheServiceVersion();
     }
 
     default void undeploy() {
@@ -39,6 +69,7 @@ public interface ContainerDeployable<T extends GenericContainer<?>> extends Depl
 
             removeImage();
         }
+        VERSION_CACHE.remove(this);
     }
 
     default String getLogs() {

--- a/system-x/common/src/main/java/software/tnb/common/service/WithServiceDefinition.java
+++ b/system-x/common/src/main/java/software/tnb/common/service/WithServiceDefinition.java
@@ -19,6 +19,10 @@ public interface WithServiceDefinition {
         return TestConfiguration.getProperty(String.format(VERSION_PROPERTY_FORMAT, key), defaultServiceVersion());
     }
 
+    default String driverVersion() {
+        return null;
+    }
+
     private String defaultServiceName() {
         String csvName = csvPart(0);
         if (csvName != null) {

--- a/system-x/common/src/main/java/software/tnb/common/util/VersionUtils.java
+++ b/system-x/common/src/main/java/software/tnb/common/util/VersionUtils.java
@@ -1,0 +1,28 @@
+package software.tnb.common.util;
+
+import software.tnb.common.deployment.Deployable;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class VersionUtils {
+
+    private VersionUtils() {
+    }
+
+    public static String extractFromLogs(Object service, Pattern pattern) {
+        if (service instanceof Deployable d) {
+            try {
+                String logs = d.getLogs();
+                if (logs != null) {
+                    Matcher m = pattern.matcher(logs);
+                    if (m.find()) {
+                        return m.group(1);
+                    }
+                }
+            } catch (Exception ignored) {
+            }
+        }
+        return null;
+    }
+}

--- a/system-x/common/src/test/java/software/tnb/service/ServiceDefinitionTest.java
+++ b/system-x/common/src/test/java/software/tnb/service/ServiceDefinitionTest.java
@@ -2,6 +2,7 @@ package software.tnb.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import software.tnb.common.deployment.ContainerDeployable;
 import software.tnb.common.deployment.WithDockerImage;
 import software.tnb.common.deployment.WithOperatorHub;
 import software.tnb.common.service.WithServiceDefinition;
@@ -9,6 +10,8 @@ import software.tnb.common.service.WithServiceDefinition;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+
+import org.testcontainers.containers.GenericContainer;
 
 @Tag("unit")
 public class ServiceDefinitionTest {
@@ -20,6 +23,7 @@ public class ServiceDefinitionTest {
     void clearProperties() {
         System.clearProperty(nameProperty);
         System.clearProperty(versionProperty);
+        ContainerDeployable.VERSION_CACHE.clear();
     }
 
     // --- serviceName tests ---
@@ -108,6 +112,32 @@ public class ServiceDefinitionTest {
         assertThat(new PlainChild().serviceVersion()).isEqualTo("99.0");
     }
 
+    // --- containerServiceVersion tests ---
+
+    @Test
+    void resolveAndCacheShouldOverrideLatestTag() {
+        ContainerChildWithVersion child = new ContainerChildWithVersion();
+        child.resolveAndCacheServiceVersion();
+        assertThat(child.serviceVersion()).isEqualTo("3.0.5");
+    }
+
+    @Test
+    void resolveAndCacheShouldNotOverridePinnedTag() {
+        assertThat(new ContainerChildPinnedWithVersion().resolveAndCacheServiceVersion()).isEqualTo("26.0-6");
+    }
+
+    @Test
+    void resolveAndCacheNullShouldFallBackToLatest() {
+        assertThat(new ContainerChildWithoutVersion().resolveAndCacheServiceVersion()).isEqualTo("latest");
+    }
+
+    // --- driverVersion tests ---
+
+    @Test
+    void driverVersionShouldBeNullByDefault() {
+        assertThat(new PlainChild().driverVersion()).isNull();
+    }
+
     // --- test stubs ---
 
     abstract static class PlainParent implements WithServiceDefinition {
@@ -192,6 +222,59 @@ public class ServiceDefinitionTest {
     static class OperatorDockerChild extends OperatorDockerParent {
         OperatorDockerChild(String csv, String image) {
             super(csv, image);
+        }
+    }
+
+    // --- container stubs for containerServiceVersion tests ---
+
+    abstract static class ContainerParent implements ContainerDeployable<GenericContainer<?>>, WithDockerImage {
+        @Override
+        public GenericContainer<?> container() {
+            return null;
+        }
+
+        @Override
+        public void openResources() {
+        }
+
+        @Override
+        public void closeResources() {
+        }
+
+        @Override
+        public String getLogs() {
+            return null;
+        }
+    }
+
+    static class ContainerChildWithVersion extends ContainerParent {
+        @Override
+        public String defaultImage() {
+            return "quay.io/fuse_qe/apache-ftp:latest";
+        }
+
+        @Override
+        public String containerServiceVersion() {
+            return "3.0.5";
+        }
+    }
+
+    static class ContainerChildPinnedWithVersion extends ContainerParent {
+        @Override
+        public String defaultImage() {
+            return "quay.io/fuse_qe/keycloak:26.0-6";
+        }
+
+        @Override
+        public String containerServiceVersion() {
+            return "99.0";
+        }
+    }
+
+    static class ContainerChildWithoutVersion extends ContainerParent {
+        @Override
+        public String defaultImage() {
+            return "quay.io/fuse_qe/apache-ftp:latest";
         }
     }
 }

--- a/system-x/services/db/common/src/main/java/software/tnb/db/common/service/SQL.java
+++ b/system-x/services/db/common/src/main/java/software/tnb/db/common/service/SQL.java
@@ -16,10 +16,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public abstract class SQL extends ConfigurableService<SQLAccount, NoClient, SQLValidation, SQLConfiguration>
     implements WithName, WithExternalHostname, WithDockerImage {
     private static final Logger LOG = LoggerFactory.getLogger(SQL.class);
+    private static final Pattern VERSION_EXTRACT = Pattern.compile("(\\d+(?:\\.\\d+)*)");
+
+    private String cachedDbVersion;
+    private String cachedDriverVersion;
+    private boolean metadataResolved;
 
     protected abstract Class<? extends SQLAccount> accountClass();
 
@@ -38,6 +45,41 @@ public abstract class SQL extends ConfigurableService<SQLAccount, NoClient, SQLV
 
     public int localPort() {
         return port();
+    }
+
+    @Override
+    public String serviceVersion() {
+        resolveMetadata();
+        if (cachedDbVersion != null) {
+            return cachedDbVersion;
+        }
+        return super.serviceVersion();
+    }
+
+    @Override
+    public String driverVersion() {
+        resolveMetadata();
+        return cachedDriverVersion;
+    }
+
+    private void resolveMetadata() {
+        if (metadataResolved) {
+            return;
+        }
+        if (validation == null) {
+            return;
+        }
+        metadataResolved = true;
+        try {
+            SQLValidation.DatabaseMetadata meta = validation.getDatabaseMetadata();
+            if (meta != null && meta.dbVersion() != null) {
+                Matcher m = VERSION_EXTRACT.matcher(meta.dbVersion());
+                cachedDbVersion = m.find() ? m.group(1) : meta.dbVersion();
+                cachedDriverVersion = meta.driverVersion();
+            }
+        } catch (Exception e) {
+            LOG.debug("Could not resolve database metadata", e);
+        }
     }
 
     @Override

--- a/system-x/services/db/common/src/main/java/software/tnb/db/common/validation/SQLValidation.java
+++ b/system-x/services/db/common/src/main/java/software/tnb/db/common/validation/SQLValidation.java
@@ -3,6 +3,9 @@ package software.tnb.db.common.validation;
 import software.tnb.common.validation.Validation;
 import software.tnb.db.common.account.SQLAccount;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -10,6 +13,8 @@ import java.sql.SQLException;
 import java.util.function.Consumer;
 
 public class SQLValidation implements Validation {
+    private static final Logger LOG = LoggerFactory.getLogger(SQLValidation.class);
+
     private final String jdbcConnectionUrl;
     private final SQLAccount account;
 
@@ -39,6 +44,19 @@ public class SQLValidation implements Validation {
             check.accept(conn.createStatement().executeQuery(sql));
         } catch (SQLException e) {
             throw new RuntimeException("Unable to execute query", e);
+        }
+    }
+
+    public record DatabaseMetadata(String dbVersion, String driverVersion) {
+    }
+
+    public DatabaseMetadata getDatabaseMetadata() {
+        try (Connection conn = DriverManager.getConnection(jdbcConnectionUrl, account.username(), account.password())) {
+            java.sql.DatabaseMetaData meta = conn.getMetaData();
+            return new DatabaseMetadata(meta.getDatabaseProductVersion(), meta.getDriverVersion());
+        } catch (SQLException e) {
+            LOG.debug("Could not query database metadata", e);
+            return null;
         }
     }
 }

--- a/system-x/services/ftp/src/main/java/software/tnb/ftp/ftp/resource/local/LocalFTP.java
+++ b/system-x/services/ftp/src/main/java/software/tnb/ftp/ftp/resource/local/LocalFTP.java
@@ -24,6 +24,18 @@ public class LocalFTP extends FTP implements ContainerDeployable<FTPContainer> {
     private final CustomFTPClient client = new TestContainerFTPOutOfBandClient();
 
     @Override
+    public String containerServiceVersion() {
+        try {
+            String v = container().execInContainer("sh", "-c", "ls -d /opt/apache-ftpserver-* | sed 's|.*/apache-ftpserver-||'")
+                .getStdout().trim();
+            return v.isEmpty() ? null : v;
+        } catch (Exception e) {
+            LOG.debug("Failed to detect FTP server version from container", e);
+            return null;
+        }
+    }
+
+    @Override
     public void openResources() {
         // noop
     }

--- a/system-x/services/infinispan/src/main/java/software/tnb/infinispan/service/Infinispan.java
+++ b/system-x/services/infinispan/src/main/java/software/tnb/infinispan/service/Infinispan.java
@@ -3,13 +3,23 @@ package software.tnb.infinispan.service;
 import software.tnb.common.client.NoClient;
 import software.tnb.common.deployment.WithDockerImage;
 import software.tnb.common.service.Service;
+import software.tnb.common.util.VersionUtils;
 import software.tnb.common.validation.NoValidation;
 import software.tnb.infinispan.account.InfinispanAccount;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public abstract class Infinispan extends Service<InfinispanAccount, NoClient, NoValidation> implements WithDockerImage {
+    private static final Pattern VERSION_PATTERN = Pattern.compile("(?:Infinispan|Data Grid) Server (\\S+)");
+
     public static final int PORT = 11222;
+
+    @Override
+    public String serviceVersion() {
+        String version = VersionUtils.extractFromLogs(this, VERSION_PATTERN);
+        return version != null ? version : super.serviceVersion();
+    }
 
     public abstract int getPortMapping();
 

--- a/system-x/services/kafka/src/main/java/software/tnb/kafka/service/Kafka.java
+++ b/system-x/services/kafka/src/main/java/software/tnb/kafka/service/Kafka.java
@@ -1,8 +1,8 @@
 package software.tnb.kafka.service;
 
 import software.tnb.common.client.NoClient;
-import software.tnb.common.deployment.Deployable;
 import software.tnb.common.service.Service;
+import software.tnb.common.util.VersionUtils;
 import software.tnb.kafka.account.KafkaAccount;
 import software.tnb.kafka.validation.KafkaValidation;
 
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public abstract class Kafka extends Service<KafkaAccount, NoClient, KafkaValidation<?>> {
@@ -30,19 +29,8 @@ public abstract class Kafka extends Service<KafkaAccount, NoClient, KafkaValidat
 
     @Override
     public String serviceVersion() {
-        if (this instanceof Deployable) {
-            try {
-                String logs = ((Deployable) this).getLogs();
-                if (logs != null) {
-                    Matcher matcher = KAFKA_VERSION_PATTERN.matcher(logs);
-                    if (matcher.find()) {
-                        return matcher.group(1);
-                    }
-                }
-            } catch (Exception ignored) {
-            }
-        }
-        return super.serviceVersion();
+        String version = VersionUtils.extractFromLogs(this, KAFKA_VERSION_PATTERN);
+        return version != null ? version : super.serviceVersion();
     }
 
     public abstract String bootstrapServers();

--- a/system-x/services/ldap/src/main/java/software/tnb/ldap/service/LDAP.java
+++ b/system-x/services/ldap/src/main/java/software/tnb/ldap/service/LDAP.java
@@ -2,6 +2,7 @@ package software.tnb.ldap.service;
 
 import software.tnb.common.deployment.WithDockerImage;
 import software.tnb.common.service.ConfigurableService;
+import software.tnb.common.util.VersionUtils;
 import software.tnb.ldap.account.LDAPAccount;
 import software.tnb.ldap.service.configuration.LDAPConfiguration;
 import software.tnb.ldap.validation.LDAPValidation;
@@ -15,11 +16,21 @@ import com.unboundid.ldap.sdk.LDAPConnectionPool;
 import com.unboundid.ldap.sdk.LDAPException;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public abstract class LDAP extends ConfigurableService<LDAPAccount, LDAPConnectionPool, LDAPValidation, LDAPConfiguration> implements
     WithDockerImage {
     private static final Logger LOG = LoggerFactory.getLogger(LDAP.class);
+    private static final Pattern VERSION_PATTERN = Pattern.compile("slapd (\\d[\\d.]*)");
+
     protected static final int PORT = 389;
+
+    @Override
+    public String serviceVersion() {
+        String version = VersionUtils.extractFromLogs(this, VERSION_PATTERN);
+        return version != null ? version : super.serviceVersion();
+    }
+
     protected boolean reachable = true;
     protected String host;
     protected int port;

--- a/system-x/services/samba/src/main/java/software/tnb/samba/resource/local/LocalSambaServer.java
+++ b/system-x/services/samba/src/main/java/software/tnb/samba/resource/local/LocalSambaServer.java
@@ -10,6 +10,19 @@ public class LocalSambaServer extends SambaServer implements ContainerDeployable
     private final SambaServerContainer container = new SambaServerContainer(image(), containerEnvironment());
 
     @Override
+    public String containerServiceVersion() {
+        try {
+            String v = container().execInContainer("sh", "-c",
+                "smbd --version 2>/dev/null | sed 's|Version ||'")
+                .getStdout().trim();
+            return v.isEmpty() ? null : v;
+        } catch (Exception e) {
+            LOG.debug("Failed to detect Samba version from container", e);
+            return null;
+        }
+    }
+
+    @Override
     public int port() {
         return container.getMappedPort(SambaServer.SAMBA_PORT_DEFAULT);
     }

--- a/system-x/services/snmp/src/main/java/software/tnb/snmp/service/SNMPServer.java
+++ b/system-x/services/snmp/src/main/java/software/tnb/snmp/service/SNMPServer.java
@@ -4,14 +4,23 @@ import software.tnb.common.account.NoAccount;
 import software.tnb.common.client.NoClient;
 import software.tnb.common.deployment.WithDockerImage;
 import software.tnb.common.service.Service;
+import software.tnb.common.util.VersionUtils;
 import software.tnb.common.validation.NoValidation;
 
 import java.util.Map;
+import java.util.regex.Pattern;
 
 public abstract class SNMPServer extends Service<NoAccount, NoClient, NoValidation> implements WithDockerImage {
+    private static final Pattern VERSION_PATTERN = Pattern.compile("NET-SNMP version (\\S+)");
 
     public static final int SNMPD_LISTENING_PORT = 1163;
     public static final int SNMPTRAPD_LISTENING_PORT = 1162;
+
+    @Override
+    public String serviceVersion() {
+        String version = VersionUtils.extractFromLogs(this, VERSION_PATTERN);
+        return version != null ? version : super.serviceVersion();
+    }
 
     @Override
     public String defaultImage() {

--- a/system-x/services/ssh/src/main/java/software/tnb/ssh/resource/local/LocalSSHServer.java
+++ b/system-x/services/ssh/src/main/java/software/tnb/ssh/resource/local/LocalSSHServer.java
@@ -13,6 +13,18 @@ public class LocalSSHServer extends SSHServer implements ContainerDeployable<SSH
     private SSHServerContainer container;
 
     @Override
+    public String containerServiceVersion() {
+        try {
+            String v = container().execInContainer("sh", "-c", "ssh -V 2>&1 | head -1 | sed 's|.*OpenSSH_||;s|[, ].*||'")
+                .getStdout().trim();
+            return v.isEmpty() ? null : v;
+        } catch (Exception e) {
+            LOG.debug("Failed to detect OpenSSH version from container", e);
+            return null;
+        }
+    }
+
+    @Override
     protected String clientHostname() {
         return host();
     }

--- a/system-x/services/telegram/src/main/java/software/tnb/telegram/resource/local/LocalTelegram.java
+++ b/system-x/services/telegram/src/main/java/software/tnb/telegram/resource/local/LocalTelegram.java
@@ -10,6 +10,19 @@ public class LocalTelegram extends Telegram implements ContainerDeployable<Teleg
     private final TelegramClientContainer container = new TelegramClientContainer(image(), getEnv());
 
     @Override
+    public String containerServiceVersion() {
+        try {
+            String v = container().execInContainer("sh", "-c",
+                "python3 -c 'import telethon; print(telethon.__version__)' 2>/dev/null")
+                .getStdout().trim();
+            return v.isEmpty() ? null : v;
+        } catch (Exception e) {
+            LOG.debug("Failed to detect Telethon version from container", e);
+            return null;
+        }
+    }
+
+    @Override
     protected String getHttpEndpoint() {
         return container.getHttpEndpoint();
     }


### PR DESCRIPTION
Add containerServiceVersion() hook in ContainerDeployable for detecting actual software versions from running containers when image tag is "latest". Add JDBC metadata-based version and driver detection in SQL parent class. Add log-based version parsing for Infinispan, LDAP, and SNMP services.