### PR TITLE
Add OCP jkube build strategy configuration — align CSB-4.18.x with main

### DIFF
--- a/fuse-products/src/main/java/software/tnb/product/csb/configuration/SpringBootConfiguration.java
+++ b/fuse-products/src/main/java/software/tnb/product/csb/configuration/SpringBootConfiguration.java
@@ -5,6 +5,8 @@ import software.tnb.product.camel.CamelConfiguration;
 
 import org.apache.commons.lang3.StringUtils;
 
+import java.util.Optional;
+
 public class SpringBootConfiguration extends CamelConfiguration {
     public static final String CAMEL_SPRINGBOOT_VERSION = "camel.springboot.version";
     public static final String SPRINGBOOT_VERSION = "springboot.version";
@@ -33,6 +35,8 @@ public class SpringBootConfiguration extends CamelConfiguration {
     public static final String OPENSHIFT_SB_RESULT_IMAGE_REPOSITORY = "openshift-sb.result-image.repo";
 
     public static final String OPENSHIFT_SB_DEPLOYMENT_FORCE = "openshift-sb.deployment.force";
+
+    public static final String OPENSHIFT_SB_BUILD_STRATEGY = "openshift-sb.build-strategy";
 
     public static String springBootVersion() {
         return getProperty(SPRINGBOOT_VERSION, "3.5.5");
@@ -114,5 +118,9 @@ public class SpringBootConfiguration extends CamelConfiguration {
      */
     public static boolean forceOpenshiftDeployment() {
         return getBoolean(OPENSHIFT_SB_DEPLOYMENT_FORCE, true);
+    }
+
+    public static Optional<String> openshiftBuildStrategy() {
+        return Optional.ofNullable(getProperty(OPENSHIFT_SB_BUILD_STRATEGY));
     }
 }

--- a/fuse-products/src/main/java/software/tnb/product/deploystrategy/impl/custom/CustomJKubeStrategy.java
+++ b/fuse-products/src/main/java/software/tnb/product/deploystrategy/impl/custom/CustomJKubeStrategy.java
@@ -94,6 +94,8 @@ public class CustomJKubeStrategy extends OpenshiftCustomDeployer {
             , "jkube.enricher.jkube-service.expose", "true"
             , "jkube.build.switchToDeployment", String.valueOf(SpringBootConfiguration.forceOpenshiftDeployment())
         ));
+        SpringBootConfiguration.openshiftBuildStrategy().ifPresent(strategy ->
+            props.put("jkube.build.strategy", strategy));
         if (ports.size() > 1) {
             props.put("jkube.enricher.jkube-service.multiPort", "true");
             //make the port configuration on the pod
@@ -187,6 +189,15 @@ public class CustomJKubeStrategy extends OpenshiftCustomDeployer {
                  new InputStreamReader(OpenshiftSpringBootApp.class.getResourceAsStream("/openshift/csb/jkube-fileset-config.xml"))) {
 
             final Xpp3Dom ompConfig = Xpp3DomBuilder.build(reader);
+
+            SpringBootConfiguration.openshiftBuildStrategy().ifPresent(strategy -> {
+                if ("docker".equalsIgnoreCase(strategy)) {
+                    Xpp3Dom buildDom = ompConfig.getChild("images").getChild("image").getChild("build");
+                    Xpp3Dom cmd = new Xpp3Dom("cmd");
+                    cmd.setValue("java ${JAVA_OPTS_APPEND} -jar /deployments/*.jar");
+                    buildDom.addChild(cmd);
+                }
+            });
 
             final Model model = Maven.loadPom(pomFile);
 


### PR DESCRIPTION
## Summary
- Cherry-pick `be425b22` from main to CSB-4.18.x, adding configurable JKube build strategy support
- This is the only remaining difference between the two branches — after this PR, CSB-4.18.x is fully aligned with main

## Changes
- `SpringBootConfiguration`: add `OPENSHIFT_SB_BUILD_STRATEGY` property and `openshiftBuildStrategy()` accessor
- `CustomJKubeStrategy`: use the build strategy property for `jkube.build.strategy` and add `cmd` element for docker strategy