### PR TITLE
Cherry-pick Jira run condition fix to CSB-4.18.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,25 @@ The code style is in the [EditorConfig](https://editorconfig.org/) [file](.edito
 
 ---
 
+### Jira issue check
+
+Tests can be annotated with `@Jira` to skip execution when a linked Jira issue is still open. The annotation queries the Jira Cloud REST API to check the issue status and skips the test if the status is not in the allowed resolutions list.
+
+```java
+@Jira(keys = "CSB-1234")
+public class MyITCase { ... }
+```
+
+The following system properties control the behavior:
+
+| Property | Description |
+|----------|-------------|
+| `jira.username` | Jira Cloud email address (used for Basic auth) |
+| `jira.token` | Jira Cloud API token |
+| `jira.allowed.resolutions` | Comma-separated list of statuses that allow the test to run (default: `Resolved, Closed, Done, Validation Backlog, In Validation`) |
+
+---
+
 For more information see the readme files in the modules.
 
 [common](common/README.md)

--- a/common/src/main/java/software/tnb/common/config/TestConfiguration.java
+++ b/common/src/main/java/software/tnb/common/config/TestConfiguration.java
@@ -40,6 +40,7 @@ public class TestConfiguration extends Configuration {
     public static final String STREAM_LOGS = "stream.logs";
     public static final String JIRA_ALLOWED_RESOLUTIONS = "jira.allowed.resolutions";
     public static final String JIRA_ACCESS_TOKEN = "jira.token";
+    public static final String JIRA_USERNAME = "jira.username";
     public static final String PARALLEL = "test.parallel";
     public static final String TEST_USE_GLOBAL_OPENSHIFT_KAFKA = "test.use.global.openshift.kafka";
 
@@ -180,6 +181,10 @@ public class TestConfiguration extends Configuration {
 
     public static String jiraAccessToken() {
         return getProperty(JIRA_ACCESS_TOKEN, "");
+    }
+
+    public static String jiraUsername() {
+        return getProperty(JIRA_USERNAME, "");
     }
 
     public static boolean parallel() {

--- a/fuse-products/src/main/java/software/tnb/product/junit/RunConditions.java
+++ b/fuse-products/src/main/java/software/tnb/product/junit/RunConditions.java
@@ -1,6 +1,7 @@
 package software.tnb.product.junit;
 
 import static software.tnb.common.config.TestConfiguration.jiraAccessToken;
+import static software.tnb.common.config.TestConfiguration.jiraUsername;
 
 import software.tnb.common.config.OpenshiftConfiguration;
 import software.tnb.common.config.TestConfiguration;
@@ -32,7 +33,7 @@ import java.util.Optional;
 
 public class RunConditions implements ExecutionCondition {
     private static final Logger LOG = LoggerFactory.getLogger(RunConditions.class);
-    private static final String JIRA_URL_PREFIX = "https://issues.redhat.com/rest/api/latest/issue/";
+    private static final String JIRA_URL_PREFIX = "https://redhat.atlassian.net/rest/api/latest/issue/";
 
     @Override
     public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
@@ -107,7 +108,7 @@ public class RunConditions implements ExecutionCondition {
         for (String jiraKey : jira.keys()) {
             LOG.trace("Checking JIRA {}, allowed resolutions: {}", jiraKey, TestConfiguration.jiraAllowedResolutions());
             final Map<String, String> headers = StringUtils.isNotBlank(jiraAccessToken()) ? Map.of(
-                "Authorization", String.format("Bearer %s", jiraAccessToken())
+                "Authorization", okhttp3.Credentials.basic(jiraUsername(), jiraAccessToken())
             ) : Map.of();
             final HTTPUtils.Response response = HTTPUtils.getInstance().get(JIRA_URL_PREFIX + jiraKey, headers);
             if (response.getResponseCode() == 200) {


### PR DESCRIPTION
## Summary
- Cherry-pick of e54ea37b from main — fixes `@Jira` annotation skip logic
- Updates Jira URL from `issues.redhat.com` to `redhat.atlassian.net` (post-migration)
- Switches auth from Bearer token to HTTP Basic (Atlassian Cloud API token format)

Without this fix, `@Jira`-annotated tests get 404 from the old Jira URL and run instead of being skipped — causing false UNSTABLE results in PR and milestone builds.

## Test plan
- [x] Verified fix is already merged and working on `main` (PR #1959)
- [ ] PR test run on CSB-4.18.x should show `@Jira` tests properly skipped