### PR TITLE
[FHIR] Use httpGet probe instead of exec/curl for health checks

### DIFF
--- a/system-x/services/fhir/src/main/java/software/tnb/fhir/resource/openshift/OpenshiftFHIR.java
+++ b/system-x/services/fhir/src/main/java/software/tnb/fhir/resource/openshift/OpenshiftFHIR.java
@@ -96,10 +96,15 @@ public class OpenshiftFHIR extends FHIR implements OpenshiftDeployable, WithName
         ).serverSideApply();
 
         final Probe probe = new ProbeBuilder()
-            .editOrNewExec()
-            .withCommand("curl", "http://0.0.0.0:8080/fhir/metadata",
-                "--header", "\"Authorization: Basic " + authToken + "\"")
-            .endExec()
+            .editOrNewHttpGet()
+                .withPath("/fhir/metadata")
+                .withPort(new IntOrString(PORT))
+                .withScheme("HTTP")
+                .addNewHttpHeader()
+                    .withName("Authorization")
+                    .withValue("Basic " + authToken)
+                .endHttpHeader()
+            .endHttpGet()
             .withInitialDelaySeconds(60)
             .withTimeoutSeconds(5)
             .withFailureThreshold(10)


### PR DESCRIPTION
## Problem

Exec-based liveness/readiness probes fail on s390x

## Changes

- Switch from exec/curl to httpGet probe in OpenshiftFHIR.java
- Auth header passed via httpGet httpHeaders (native Kubernetes support)
- No other changes to deployment logic, service account, or route setup

Tested on Jenkins CSB job for s390x and x86.