### PR TITLE
[Keycloak] Fix container unreachable on Windows (W2K25)

### DIFF
--- a/system-x/services/keycloak/src/main/java/software/tnb/keycloak/resource/local/KeycloakContainer.java
+++ b/system-x/services/keycloak/src/main/java/software/tnb/keycloak/resource/local/KeycloakContainer.java
@@ -4,18 +4,16 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 
 public class KeycloakContainer extends GenericContainer<KeycloakContainer> {
 
     public KeycloakContainer(String image, Map<String, String> env, String[] startupParameters, int port) {
         super(image);
-        this.setPortBindings(List.of("8080:8080"));
         this.withEnv(env);
-        this.withNetworkMode("host");
+        this.addExposedPort(port);
         this.withNetworkAliases("keycloak");
         setCommandParts(startupParameters);
-        this.waitingFor(Wait.forLogMessage(".*Keycloak.*started.*", 1)).withStartupTimeout(Duration.ofMinutes(2));
+        this.waitingFor(Wait.forLogMessage(".*Keycloak.*started.*", 1)).withStartupTimeout(Duration.ofMinutes(5));
     }
 }

--- a/system-x/services/keycloak/src/main/java/software/tnb/keycloak/resource/local/LocalKeycloak.java
+++ b/system-x/services/keycloak/src/main/java/software/tnb/keycloak/resource/local/LocalKeycloak.java
@@ -16,7 +16,7 @@ public class LocalKeycloak extends Keycloak implements ContainerDeployable<Keycl
 
     @Override
     public int port() {
-        return PORT;
+        return container.getMappedPort(PORT);
     }
 
     @Override

--- a/system-x/services/keycloak/src/main/java/software/tnb/keycloak/validation/KeycloakValidation.java
+++ b/system-x/services/keycloak/src/main/java/software/tnb/keycloak/validation/KeycloakValidation.java
@@ -29,13 +29,14 @@ public class KeycloakValidation implements Validation {
     private static final String openIDClientForm = "grant_type=password&client_id=%s&client_secret=%s";
 
     public KeycloakValidation(String host, int port) {
-        if ("localhost".equals(host)) {
+        if ("localhost".equals(host) || host.matches("\\d+\\.\\d+\\.\\d+\\.\\d+")) {
             serviceHost = String.format("http://%s:%s", host, port);
         } else {
             serviceHost = String.format("https://%s", host);
         }
 
         httpUtils = HTTPUtils.getInstance(HTTPUtils.trustAllSslClient()).withRetry();
+        LOG.debug("Keycloak service host: {}", serviceHost);
     }
 
     public String getServiceHost() {
@@ -51,11 +52,12 @@ public class KeycloakValidation implements Validation {
                 try {
                     resp.set(postServerRealmsApi(tokenApiUrl, realm, body, "application/x-www-form-urlencoded"));
                 } catch (RuntimeException e) {
-                    LOG.warn("Waiting for service availability");
+                    LOG.warn("Waiting for Keycloak token endpoint availability: {}",
+                        e.getCause() != null ? e.getCause().toString() : e.getMessage());
                 }
                 return (resp.get() != null && resp.get().isSuccessful());
             }, 5, 60000
-            , "Wait until the call is successful");
+            , "Waiting for Keycloak token for realm " + realm);
 
         JsonObject jsonResp = new Gson().fromJson(resp.get().getBody(), JsonObject.class);
 
@@ -73,11 +75,11 @@ public class KeycloakValidation implements Validation {
                 try {
                     resp.set(postServerApi(realmsUrl, bodyRealmContent, "application/json", headers));
                 } catch (RuntimeException e) {
-                    LOG.warn("Waiting for service availability");
+                    LOG.warn("Waiting for Keycloak realm upload availability: {}", e.getMessage());
                 }
                 return (resp.get() != null && resp.get().isSuccessful());
             }, 5, 60000
-            , "Wait until the call is successful");
+            , "Waiting for Keycloak realm upload");
 
         return resp.get();
     }
@@ -88,12 +90,12 @@ public class KeycloakValidation implements Validation {
                 try {
                     postServerApi(realmsUrl, realmName, "application/json", headers);
                 } catch (RuntimeException e) {
-                    LOG.warn("Waiting for service availability");
+                    LOG.warn("Waiting for Keycloak realm deletion availability: {}", e.getMessage());
                     return false;
                 }
                 return true;
             }, 5, 60000
-            , "Wait until the call is successful");
+            , "Waiting for Keycloak realm deletion");
     }
 
     private HTTPUtils.Response postServerRealmsApi(String url, String realm, String body, String mediaType) {


### PR DESCRIPTION
Three issues prevented the Keycloak testcontainer from being reachable on Windows Server:

1. --network=host is not supported for Linux containers on Windows. On Windows, use testcontainers' addExposedPort + getMappedPort instead of fixed port bindings and host networking.

2. Docker's WinNAT port mapping via setPortBindings is unreliable on Windows Server. Using addExposedPort lets testcontainers handle port mapping internally.

3. container.getHost() returns an IP address (not "localhost") on Windows Server. KeycloakValidation only checked for "localhost" to decide HTTP vs HTTPS, so it fell through to HTTPS on port 443. Now also matches IPv4 addresses as local containers.

Also increase container startup timeout to 5 minutes for slower platforms, log serviceHost URL on construction, and log the actual IOException cause on token/realm wait failures.