### PR TITLE
Align system-x services with CSB-4.18.x branch

### DIFF
--- a/system-x/services/ai/docling-serve/src/main/java/software/tnb/docling/serve/resource/local/DoclingServeContainer.java
+++ b/system-x/services/ai/docling-serve/src/main/java/software/tnb/docling/serve/resource/local/DoclingServeContainer.java
@@ -3,11 +3,13 @@ package software.tnb.docling.serve.resource.local;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.time.Duration;
+
 public class DoclingServeContainer extends GenericContainer<DoclingServeContainer> {
 
     public DoclingServeContainer(String image, int port) {
         super(image);
         this.withExposedPorts(port);
-        this.waitingFor(Wait.forHttp("/health").forPort(port).forStatusCode(200));
+        this.waitingFor(Wait.forHttp("/health").forPort(port).forStatusCode(200).withStartupTimeout(Duration.ofMinutes(10)));
     }
 }

--- a/system-x/services/ai/docling-serve/src/main/java/software/tnb/docling/serve/service/DoclingServe.java
+++ b/system-x/services/ai/docling-serve/src/main/java/software/tnb/docling/serve/service/DoclingServe.java
@@ -14,6 +14,6 @@ public abstract class DoclingServe extends Service<NoAccount, NoClient, NoValida
 
     @Override
     public String defaultImage() {
-        return "quay.io/docling-project/docling-serve:v1.16.1";
+        return "quay.io/docling-project/docling-serve:v1.25.0";
     }
 }

--- a/system-x/services/azure/storage-blob/pom.xml
+++ b/system-x/services/azure/storage-blob/pom.xml
@@ -14,7 +14,7 @@
     <name>TNB :: System-X :: Services :: Azure :: Storage :: Blob</name>
 
     <properties>
-        <azure.storage.blob.version>12.35.0</azure.storage.blob.version>
+        <azure.storage.blob.version>12.34.0</azure.storage.blob.version>
     </properties>
 
     <dependencies>

--- a/system-x/services/azure/storage-common/pom.xml
+++ b/system-x/services/azure/storage-common/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <!-- Align the version, as blob and queue may contain different versions -->
-        <azure.storage.common.version>12.34.0</azure.storage.common.version>
+        <azure.storage.common.version>12.33.0</azure.storage.common.version>
     </properties>
 
     <dependencies>

--- a/system-x/services/azure/storage-data-lake/pom.xml
+++ b/system-x/services/azure/storage-data-lake/pom.xml
@@ -14,7 +14,7 @@
     <name>TNB :: System-X :: Services :: Azure :: Storage :: DataLake</name>
 
     <properties>
-        <azure.storage.file.datalake.version>12.28.0</azure.storage.file.datalake.version>
+        <azure.storage.file.datalake.version>12.27.0</azure.storage.file.datalake.version>
     </properties>
 
     <dependencies>

--- a/system-x/services/azure/storage-queue/pom.xml
+++ b/system-x/services/azure/storage-queue/pom.xml
@@ -14,7 +14,7 @@
     <name>TNB :: System-X :: Services :: Azure :: Storage :: Queue</name>
 
     <properties>
-        <azure.storage.queue.version>12.30.0</azure.storage.queue.version>
+        <azure.storage.queue.version>12.29.0</azure.storage.queue.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary
Port all system-x/services changes from `CSB-4.18.x` to `main`:

- **DoclingServe**: bump image from `v1.16.1` to `v1.25.0`
- **DoclingServe**: increase container startup timeout to 10 minutes
- **Azure Storage Blob**: `12.35.0` → `12.34.0`
- **Azure Storage Common**: `12.34.0` → `12.33.0`
- **Azure Storage DataLake**: `12.28.0` → `12.27.0`
- **Azure Storage Queue**: `12.30.0` → `12.29.0`

## Test plan
- [ ] Verify DoclingServe tests pass with the new image version
- [ ] Verify Azure storage tests compile and pass with aligned versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)