### PR TITLE
[DoclingServe] Update image to v1.25.0 and increase startup timeout

### DIFF
--- a/common/src/main/resources/testcontainers.properties
+++ b/common/src/main/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+pull.timeout=600

--- a/system-x/services/ai/docling-serve/src/main/java/software/tnb/docling/serve/resource/local/DoclingServeContainer.java
+++ b/system-x/services/ai/docling-serve/src/main/java/software/tnb/docling/serve/resource/local/DoclingServeContainer.java
@@ -3,11 +3,13 @@ package software.tnb.docling.serve.resource.local;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.time.Duration;
+
 public class DoclingServeContainer extends GenericContainer<DoclingServeContainer> {
 
     public DoclingServeContainer(String image, int port) {
         super(image);
         this.withExposedPorts(port);
-        this.waitingFor(Wait.forHttp("/health").forPort(port).forStatusCode(200));
+        this.waitingFor(Wait.forHttp("/health").forPort(port).forStatusCode(200).withStartupTimeout(Duration.ofMinutes(10)));
     }
 }

--- a/system-x/services/ai/docling-serve/src/main/java/software/tnb/docling/serve/service/DoclingServe.java
+++ b/system-x/services/ai/docling-serve/src/main/java/software/tnb/docling/serve/service/DoclingServe.java
@@ -14,6 +14,6 @@ public abstract class DoclingServe extends Service<NoAccount, NoClient, NoValida
 
     @Override
     public String defaultImage() {
-        return "quay.io/docling-project/docling-serve:v1.16.1";
+        return "quay.io/docling-project/docling-serve:v1.25.0";
     }
 }


### PR DESCRIPTION
## Summary
Port DoclingServe changes from CSB-4.18.x to main:

- Bump docling-serve image from `v1.16.1` to `v1.25.0`
- Increase container startup timeout to 10 minutes (newer image takes longer to initialize)

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)