### PR TITLE
[Accounts] Fix setWebhookUrl setter parameter name (camelCase)

### DIFF
--- a/system-x/services/microsoft/src/main/java/software/tnb/microsoft/account/MicrosoftAccount.java
+++ b/system-x/services/microsoft/src/main/java/software/tnb/microsoft/account/MicrosoftAccount.java
@@ -5,9 +5,9 @@ import software.tnb.common.account.WithId;
 
 public class MicrosoftAccount implements Account, WithId {
     private String username;
-    private String client_id;
-    private String client_secret;
-    private String tenant_id;
+    private String clientId;
+    private String clientSecret;
+    private String tenantId;
 
     @Override
     public String credentialsId() {
@@ -23,26 +23,26 @@ public class MicrosoftAccount implements Account, WithId {
     }
 
     public String clientId() {
-        return client_id;
+        return clientId;
     }
 
-    public void setClient_id(String client_id) {
-        this.client_id = client_id;
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
     }
 
     public String clientSecret() {
-        return client_secret;
+        return clientSecret;
     }
 
-    public void setClient_secret(String client_secret) {
-        this.client_secret = client_secret;
+    public void setClientSecret(String clientSecret) {
+        this.clientSecret = clientSecret;
     }
 
     public String tenantId() {
-        return tenant_id;
+        return tenantId;
     }
 
-    public void setTenant_id(String tenant_id) {
-        this.tenant_id = tenant_id;
+    public void setTenantId(String tenant_id) {
+        this.tenantId = tenant_id;
     }
 }

--- a/system-x/services/slack/src/main/java/software/tnb/slack/account/SlackAccount.java
+++ b/system-x/services/slack/src/main/java/software/tnb/slack/account/SlackAccount.java
@@ -8,14 +8,14 @@ import java.util.Map;
 /**
  * Requires following slack account definition:
  *
- *   slack-tnb:
+ *   slack:
  *     credentials:
  *       token: [token]
  *       channels:
  *         [identifier]:
  *           name: [channelName] (optional, if not present, identifier is used)
- *           webhook_url: [webhook url]
- *           channel_id: [channel id]
+ *           webhookUrl: [webhook url]
+ *           channelId: [channel id]
  *         ...
  */
 public class SlackAccount implements Account, WithId {
@@ -77,8 +77,8 @@ public class SlackAccount implements Account, WithId {
             return webhookUrl;
         }
 
-        public void setWebhookUrl(String webhook_url) {
-            this.webhookUrl = webhook_url;
+        public void setWebhookUrl(String webhookUrl) {
+            this.webhookUrl = webhookUrl;
         }
 
         public String channelId() {


### PR DESCRIPTION
Port missing fix from `main`: the `SlackAccount.ChannelAccount#setWebhookUrl` setter parameter was using `webhook_url` (snake_case) while all other setters in the refactor used camelCase. This aligns it with the rest of the `[Accounts] Refactor classnames and ids` commit already present in this branch.

The other commits from `main` (`[Credentials] Add env credentials loader` and `docling: update image and increase timeouts`) were already present in `CSB-4.18.x` and produced empty cherry-picks.