### PR TITLE
CSB-9997: Use Red Hat Undertow starter for Spring Boot 4 compatibility

### DIFF
--- a/fuse-products/src/main/java/software/tnb/product/customizer/component/rest/RestCustomizer.java
+++ b/fuse-products/src/main/java/software/tnb/product/customizer/component/rest/RestCustomizer.java
@@ -31,7 +31,7 @@ public class RestCustomizer extends ProductsCustomizer {
                     "org.springframework.boot:spring-boot-starter-tomcat")
                 )
                 .dependencies(
-                    Maven.createDependency("org.springframework.boot:spring-boot-starter-undertow")
+                    Maven.createDependency("com.redhat.integration:spring-boot-starter-undertow")
                 );
         }
     }

--- a/fuse-products/src/test/java/software/tnb/product/customizer/component/RestCustomizerTest.java
+++ b/fuse-products/src/test/java/software/tnb/product/customizer/component/RestCustomizerTest.java
@@ -38,7 +38,7 @@ public class RestCustomizerTest extends ProductCustomizerTestParent {
         assertThat(d.getExclusions().get(0).getArtifactId()).isEqualTo("spring-boot-starter-tomcat");
 
         d = ib.getDependencies().get(1);
-        assertThat(d.getGroupId()).isEqualTo("org.springframework.boot");
+        assertThat(d.getGroupId()).isEqualTo("com.redhat.integration");
         assertThat(d.getArtifactId()).isEqualTo("spring-boot-starter-undertow");
     }
 


### PR DESCRIPTION
Replace org.springframework.boot:spring-boot-starter-undertow with com.redhat.integration:spring-boot-starter-undertow which is compatible with Spring Boot 4 and provides undertow-servlet transitively.