### PR TITLE
Bump spring-vault-core from 3.2.0 to 4.1.0

### DIFF
--- a/system-x/services/hashicorp-vault/pom.xml
+++ b/system-x/services/hashicorp-vault/pom.xml
@@ -14,7 +14,7 @@
     <name>TNB :: System-X :: Services :: Hashicorp Vault</name>
 
     <properties>
-        <spring-vault-core-version>3.2.0</spring-vault-core-version>
+        <spring-vault-core-version>4.1.0</spring-vault-core-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
spring-vault 3.2.0 is incompatible with Spring Framework 7 (Spring Boot 4). The RestTemplate(List) constructor was removed in SF7, causing NoSuchMethodError at runtime.