### PR TITLE
Fix Infinispan default image: pin datagrid-8-rhel9 to 1.6 instead of latest

### DIFF
--- a/system-x/services/infinispan/src/main/java/software/tnb/infinispan/service/Infinispan.java
+++ b/system-x/services/infinispan/src/main/java/software/tnb/infinispan/service/Infinispan.java
@@ -30,6 +30,6 @@ public abstract class Infinispan extends Service<InfinispanAccount, NoClient, No
     }
 
     public String defaultImage() {
-        return "registry.redhat.io/datagrid/datagrid-8-rhel9:latest";
+        return "registry.redhat.io/datagrid/datagrid-8-rhel9:1.6";
     }
 }


### PR DESCRIPTION
The 'latest' tag is no longer available. Pinning to 1.6 which is the current stable Data Grid 8 release.