### PR TITLE
Fix SalesforceAccount: rename setUserName to setUsername for correct …

### DIFF
--- a/system-x/services/salesforce/src/main/java/software/tnb/salesforce/account/SalesforceAccount.java
+++ b/system-x/services/salesforce/src/main/java/software/tnb/salesforce/account/SalesforceAccount.java
@@ -8,7 +8,7 @@ public class SalesforceAccount implements Account, WithId {
     private String loginUrl;
     private String clientId;
     private String clientSecret;
-    private String username;
+    private String userName;
     private String password;
     private String secureSocketProtocol;
 
@@ -50,11 +50,11 @@ public class SalesforceAccount implements Account, WithId {
     }
 
     public String userName() {
-        return username;
+        return userName;
     }
 
     public void setUsername(String username) {
-        this.username = username;
+        this.userName = username;
     }
 
     public String password() {


### PR DESCRIPTION
…Jackson deserialization

Account.toProperties() uses field names via reflection. Field 'userName' correctly produces property key 'userName', matching the salesforce-source kamelet mandatory parameter. However, setter 'setUserName()' maps to JSON key 'userName' in Jackson, while credentials YAML uses lowercase 'username:' key — so the field was never set, causing 'mandatory parameters must be provided: userName' at camel export time.

Renaming the setter to 'setUsername()' aligns Jackson deserialization with the credentials YAML format while keeping the field as 'userName' so toProperties() still produces the correct kamelet parameter key.