### PR TITLE
CSB-7346: Fix deleteEmail to use variable, filter by subject, delete …

### DIFF
--- a/system-x/services/microsoft/src/main/java/software/tnb/microsoft/validation/GraphValidation.java
+++ b/system-x/services/microsoft/src/main/java/software/tnb/microsoft/validation/GraphValidation.java
@@ -49,13 +49,16 @@ public class GraphValidation implements Validation {
         client.users().byUserId(from).sendMail().post(sendMailPostRequestBody);
     }
 
-    public void deleteEmail(String subject, String content, String from) {
-        final List<Message> value = client.users().byUserId(from).messages().get().getValue();
-        Message top = value.get(0);
-
-        if ("from".equals(top.getSender().getEmailAddress().getAddress()) && subject.equals(top.getSubject())
-            && top.getBodyPreview().equals(content)) {
-            client.users().byUserId(from).messages().byMessageId(top.getId()).delete();
+    public void deleteEmail(String subject, String content, String userId) {
+        final List<Message> messages = client.users().byUserId(userId).messages().get(config ->
+            config.queryParameters.filter = "subject eq '" + subject + "'"
+        ).getValue();
+        if (messages == null) {
+            return;
         }
+        messages.stream()
+            .filter(msg -> subject.equals(msg.getSubject())
+                && msg.getBodyPreview().equals(content))
+            .forEach(msg -> client.users().byUserId(userId).messages().byMessageId(msg.getId()).delete());
     }
 }


### PR DESCRIPTION
…all matches

- Fix "from" string literal bug (condition was always false, delete never ran)
- Filter messages by subject server-side instead of fetching all and checking get(0)
- Iterate all matches to handle leftover emails from previous failed runs